### PR TITLE
mstpd: use 'versionsort' by default

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -12,7 +12,7 @@ BUILDDEF = $(shell git log --pretty=format:'%h' -n 1)
 
 mstpd_CFLAGS = \
 	-Os -Wall -Werror -D_REENTRANT -D__LINUX__ -DVERSION=$(VERSION) -DBUILD="$(BUILDDEF)" -I. \
-	-D_GNU_SOURCE -D__LIBC_HAS_VERSIONSORT__
+	-D_GNU_SOURCE
 if ENABLE_DEVEL
   mstpd_CFLAGS += -g3 -O0
 endif

--- a/ctl_main.c
+++ b/ctl_main.c
@@ -32,12 +32,6 @@
 #include "ctl_socket_client.h"
 #include "log.h"
 
-#ifdef  __LIBC_HAS_VERSIONSORT__
-#define sorting_func    versionsort
-#else
-#define sorting_func    alphasort
-#endif
-
 static int get_index_die(const char *ifname, const char *doc, bool die)
 {
     int r = if_nametoindex(ifname);
@@ -304,7 +298,7 @@ static int isbridge(const struct dirent *entry)
 
 static inline int get_bridge_list(struct dirent ***namelist)
 {
-    return scandir(SYSFS_CLASS_NET, namelist, isbridge, sorting_func);
+    return scandir(SYSFS_CLASS_NET, namelist, isbridge, versionsort);
 }
 
 static int cmd_showbridge(int argc, char *const *argv)
@@ -707,7 +701,7 @@ static int get_port_list(const char *br_ifname, struct dirent ***namelist)
     char buf[SYSFS_PATH_MAX];
 
     snprintf(buf, sizeof(buf), SYSFS_CLASS_NET "/%s/brif", br_ifname);
-    if(0 > (res = scandir(buf, namelist, not_dot_dotdot, sorting_func)))
+    if(0 > (res = scandir(buf, namelist, not_dot_dotdot, versionsort)))
         fprintf(stderr, "Error getting list of all ports of bridge %s\n",
                 br_ifname);
     return res;


### PR DESCRIPTION
According to glibc's changelog ([this older one](https://sourceware.org/git/?p=glibc.git;a=blob;f=ChangeLog.8;h=52b85a627091757f17056be0ff340e3e305b0cf1;hb=HEAD#l1113) ),
versionsort should be in glibc since 1998 (or so)

uClibc implements it: https://git.uclibc.org/uClibc/tree/libc/misc/dirent/versionsort.c
musl libc implements it: https://git.musl-libc.org/cgit/musl/tree/src/dirent/versionsort.c

Unless, we'll get a report for another libc that may not
implement it, we'll stick with this just being available by default.

Resolves: https://github.com/mstpd/mstpd/issues/11

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>