### PR TITLE
bridge-stp.in: add a sleep to the mstpctl background workaround

### DIFF
--- a/bridge-stp.in
+++ b/bridge-stp.in
@@ -127,7 +127,7 @@ case "$action" in
             # then dying before or when mstpctl connects to it.  To avoid that
             # possibility, we instead simply turn STP off if `mstpctl addbridge`
             # fails.
-            ( "$mstpctl" addbridge "$bridge" || brctl stp "$bridge" off ) &
+            ( sleep 1 ; "$mstpctl" addbridge "$bridge" || brctl stp "$bridge" off ) &
             exit 0
         fi
 


### PR DESCRIPTION
It happens that the background job to add the bridge running to early before the parent shell actually exits. The msptctl call is failing then and STP mode is turned off.
Add a sleep 1 as a workaround.
(Happened to me almost every time during booting of a device running mstpd on OpenWrt.)