### PR TITLE
debian: add override for script-not-executable LW

### DIFF
--- a/debian/mstpd.lintian-overrides
+++ b/debian/mstpd.lintian-overrides
@@ -1,1 +1,2 @@
 mstpd: read-in-maintainer-script
+mstpd: script-not-executable lib/mstpctl-utils/mstpctl-utils-functions.sh


### PR DESCRIPTION
utils/mstpctl-utils-functions.sh is a bash library, so it is not
supposed to be ran individually. It has a shebang as it was
recommended by shellcheck, so Lintian generates a false positive.
Override it.