### PR TITLE
build,travis: add support for debian's travis script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,18 @@ git:
 language: c
 os: linux
 compiler: gcc
+services:
+  - docker
 addons:
   apt:
     sources:
     - debian-sid
     packages:
     - shellcheck
+env:
+  - TRAVIS_DEBIAN_DISTRIBUTION="${TRAVIS_DEBIAN_DISTRIBUTION:-experimental}"
 script:
   - set -e
   - shellcheck utils/ifupdown.sh.in utils/mstp_config_bridge.in utils/mstpctl-utils-functions.sh
   - ./autogen.sh && ./configure && make V=s
+  - wget -O- http://travis.debian.net/script.sh | sh -


### PR DESCRIPTION
Adapted from: http://travis.debian.net/

@bluca

https://travis-ci.org/commodo/mstpd/builds/233154741

AFAICT, the build looks passing ; 
tho, the lintian checks/warnings did not produce a build failure
not sure if they should
```
warning: the authors of lintian do not recommend running it with root privileges!
W: mstpd: binary-without-manpage sbin/bridge-stp
W: mstpd: binary-without-manpage sbin/mstp_restart
W: mstpd: binary-without-manpage sbin/mstpd
W: mstpd: script-not-executable lib/mstpctl-utils/mstpctl-utils-functions.sh
```

I don't get why the warning `warning: the authors of lintian do not recommend running it with root privileges!`
maybe that's caused by the fact that it's run in docker

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>