### PR TITLE
bridge-stp.in: test config_cmd for executability

### DIFF
--- a/bridge-stp.in
+++ b/bridge-stp.in
@@ -212,7 +212,7 @@ case "$action" in
             # Add bridge to mstpd and configure.
             echo "Adding/configuring bridge '$bridge' ..."
             "$mstpctl" addbridge "$bridge" || continue
-            if [ -n "$config_cmd" ]; then
+            if [ -x "$config_cmd" ] || type "$config_cmd" 2>/dev/null >/dev/null ; then
                 "$config_cmd" "$bridge"
             fi
         done


### PR DESCRIPTION
A re-spin of https://github.com/mstpd/mstpd/pull/37.

This change checks if the config_cmd is executable,
or checks if the command is in the PATH env var.

I referenced the `type` command from an OpenWrt script.

Hopefully that would ensure that it's portable enough
across other shells as well.
Seems to work on bash & zsh too.

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>