### PR TITLE
ctl_main: fix truncation warnings/errors caught by GCC 7

### DIFF
--- a/ctl_main.c
+++ b/ctl_main.c
@@ -290,7 +290,9 @@ static int isbridge(const struct dirent *entry)
     bool result;
     struct stat st;
 
-    snprintf(path, SYSFS_PATH_MAX, SYSFS_CLASS_NET "/%s/bridge",
+    /* strlen(SYSFS_CLASS_NET) + strlen("/%.230s/bridge") must be < SYSFS_PATH_MAX
+       to prevent string truncation ; gcc7's fortify headers complain about that */
+    snprintf(path, SYSFS_PATH_MAX, SYSFS_CLASS_NET "/%.230s/bridge",
              entry->d_name);
     save_errno = errno;
     result = (0 == stat(path, &st)) && S_ISDIR(st.st_mode);
@@ -702,7 +704,9 @@ static int get_port_list(const char *br_ifname, struct dirent ***namelist)
     int res;
     char buf[SYSFS_PATH_MAX];
 
-    snprintf(buf, sizeof(buf), SYSFS_CLASS_NET "/%s/brif", br_ifname);
+    /* strlen(sysfs_class_net) + strlen("/%.230s/brif") must be < sizeof(buf)
+       to prevent truncation ; gcc7's fortify headers complain about that */
+    snprintf(buf, sizeof(buf), SYSFS_CLASS_NET "/%.230s/brif", br_ifname);
     if(0 > (res = scandir(buf, namelist, not_dot_dotdot, versionsort)))
         fprintf(stderr, "Error getting list of all ports of bridge %s\n",
                 br_ifname);


### PR DESCRIPTION
GCC 7 caught this:
```
ctl_main.c: In function 'isbridge':
ctl_main.c:283:25: error: '%s' directive output may be truncated writing up to 255 bytes into a region of size 241 [-Werror=format-truncation=]
^

ctl_main.c:293:36: note: in expansion of macro 'SYSFS_CLASS_NET'
snprintf(path, SYSFS_PATH_MAX, SYSFS_CLASS_NET "/%s/bridge",
^~~~~~~~~~~~~~~

ctl_main.c:705:50: note: format string is defined here
snprintf(buf, sizeof(buf), SYSFS_CLASS_NET "/%s/brif", br_ifname);
^~
In file included from /usr/include/stdio.h:938:0,
from log.h:30,
from ctl_main.c:35:
/usr/include/x86_64-linux-gnu/bits/stdio2.h:64:10: note: '__builtin___snprintf_chk' output between 23 and 278 bytes into a destination of size 256
return __builtin___snprintf_chk (__s, __n, __USE_FORTIFY_LEVEL - 1,
^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
__bos (__s), __fmt, __va_arg_pack ());
```

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>