### PR TITLE
Correct the payload type of IFLA_OPERSTATE from int to __u8

### DIFF
--- a/brmon.c
+++ b/brmon.c
@@ -105,7 +105,7 @@ static int dump_msg(const struct sockaddr_nl *who, struct nlmsghdr *n,
 
     if(tb[IFLA_OPERSTATE])
     {
-        int state = *(int*)RTA_DATA(tb[IFLA_OPERSTATE]);
+        __u8 state = *(__u8*)RTA_DATA(tb[IFLA_OPERSTATE]);
         switch (state)
         {
             case IF_OPER_UNKNOWN:


### PR DESCRIPTION
Since the data is padded with zeroes to 4-byte boundaries it effectively worked on little endian machines, although unless I'm missing something it wouldn't work at all on big endian platforms.

https://github.com/torvalds/linux/blob/50c4c4e268a2d7a3e58ebb698ac74da0de40ae36/net/core/rtnetlink.c#L1555

I suspect it might also create an out-of bound access if this is the last entry in the buffer (since the payload is only one byte). This is rather unlikely however.

