### PR TITLE
Close control socket on termination

### DIFF
--- a/main.c
+++ b/main.c
@@ -178,6 +178,7 @@ int main(int argc, char *argv[])
 
     c = epoll_main_loop(&quit);
     bridge_track_fini();
+    ctl_socket_cleanup();
     driver_mstp_fini();
 
     return c;


### PR DESCRIPTION
On issuing a /sbin/mstp_restart command the daemon would occasionally
fail with "error, server_socket: Couldn't bind socket: Address already
in use".

On termination explicitly close the server socket
(ctl_socket_cleanup()).