### PR TITLE
.travis.yml: switch to Ubuntu Xenial distro for testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,9 @@ os: linux
 compiler: gcc
 services:
   - docker
+dist: xenial
 addons:
   apt:
-    sources:
-    - debian-sid
     packages:
     - shellcheck
 env:


### PR DESCRIPTION
Not sure which is the default distro in Travis CI at the moment.
But, it allows the use of Ubuntu Xenial (16.04 which is great because
that's pretty recent compared to Trusty (14.04) or Precise (12.04)

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>