### PR TITLE
Check STP state before terminating MSTPd

### DIFF
--- a/bridge-stp.in
+++ b/bridge-stp.in
@@ -185,6 +185,7 @@ case "$action" in
             fi
 
             # If bridge is in user_stp mode, then it is probably using MSTP.
+            read State < "$net_dir/$bridge/bridge/stp_state"
             if [ "$State" = '2' ]; then
                 exit 0
             fi

--- a/bridge_track.c
+++ b/bridge_track.c
@@ -148,6 +148,9 @@ static bool delete_br_byindex(int if_index)
     bridge_t *br;
     if(!(br = find_br(if_index)))
         return false;
+
+    INFO("Delete bridge %s (%d)", br->sysdeps.name, if_index);
+
     list_del(&br->list);
     MSTP_IN_delete_bridge(br);
     free(br);


### PR DESCRIPTION
When STP is turned off on an interface, check all other bridge/switch
instances to see if user-mode STP is enabled. Only terminate the
daemon (SIGTERM) if there are no other bridge/switch interfaces in use
by the daemon.