### PR TITLE
utils: use `command -v` built-in instead of `which`

### DIFF
--- a/utils/ifupdown.sh.in
+++ b/utils/ifupdown.sh.in
@@ -25,12 +25,12 @@ mstpctl='@mstpctlfile@'
 if [ ! -x "$mstpctl" ]; then
   exit 0
 fi
-brctl="$(which brctl)"
+brctl="$(command -v brctl)"
 if [ -z "$brctl" ] || [ ! -x "$brctl" ]; then
   echo "'brctl' binary does not exist or is not executable" >&2
   exit 2
 fi
-ip="$(which ip)"
+ip="$(command -v ip)"
 if [ -z "$ip" ] || [ ! -x "$ip" ]; then
   echo "'ip' binary does not exist or is not executable" >&2
   exit 2

--- a/utils/mstp_config_bridge.in
+++ b/utils/mstp_config_bridge.in
@@ -39,19 +39,19 @@ if [ ! -x "$mstpctl" ]; then
   echo "'mstpctl' binary does not exist or is not executable" >&2
   exit 2
 fi
-brctl="$(which brctl)"
+brctl="$(command -v brctl)"
 if [ -z "$brctl" ] || [ ! -x "$brctl" ]; then
   echo "'brctl' binary does not exist or is not executable" >&2
   exit 2
 fi
-ip="$(which ip)"
+ip="$(command -v ip)"
 if [ -z "$ip" ] || [ ! -x "$ip" ]; then
   echo "'ip' binary does not exist or is not executable" >&2
   exit 2
 fi
 
 # Find ifquery.
-ifquery="$(which ifquery 2>/dev/null)"
+ifquery="$(command -v ifquery 2>/dev/null)"
 if [ -z "$ifquery" ]; then
     # If the real ifquery is not installed, use our emulator.
     ifquery='@ifqueryfile@'


### PR DESCRIPTION
shellcheck started complaining about this new issue.
Link:
   https://github.com/koalaman/shellcheck/wiki/SC2230

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>