### PR TITLE
main.c: free file pointer when exiting

### DIFF
--- a/main.c
+++ b/main.c
@@ -170,6 +170,7 @@ int main(int argc, char *argv[])
         if(daemon(0, 0))
         {
             ERROR("can't daemonize");
+            fclose(f);
             return -1;
         }
         fprintf(f, "%d", getpid());


### PR DESCRIPTION
In most cases, that file-pointer and descriptor will be released since the
app terminates.

However, it's good practice to free it before doing that.

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>