### PR TITLE
Disable STP processing on a specific port

### DIFF
--- a/ctl_main.c
+++ b/ctl_main.c
@@ -157,6 +157,7 @@ typedef enum {
     PARAM_DISPUTED,
     PARAM_BPDUGUARDPORT,
     PARAM_BPDUGUARDERROR,
+    PARAM_BPDUFILTERPORT,
     PARAM_NETWORKPORT,
     PARAM_BA_INCONSISTENT,
     PARAM_NUMTXBPDU,
@@ -703,6 +704,7 @@ static const cmd_param_t cist_port_params[] = {
     { PARAM_DISPUTED,       "disputed" },
     { PARAM_BPDUGUARDPORT,  "bpdu-guard-port" },
     { PARAM_BPDUGUARDERROR, "bpdu-guard-error" },
+    { PARAM_BPDUFILTERPORT, "bpdu-filter-port" },
     { PARAM_NETWORKPORT,    "network-port" },
     { PARAM_BA_INCONSISTENT,"ba-inconsistent" },
     { PARAM_NUMTXBPDU,      "num-tx-bpdu" },
@@ -781,6 +783,9 @@ static int do_showport_fmt_plain(const CIST_PortStatus *s,
                        BOOL_STR(s->network_port));
                 printf("BA inconsistent      %s\n",
                        BOOL_STR(s->ba_inconsistent));
+                printf("  bpdu filter port   %-23s ",
+                       BOOL_STR(s->bpdu_filter_port));
+                printf("Num RX BPDU Filtered %u\n", s->num_rx_bpdu_filtered);
                 printf("  Num TX BPDU        %-23u ", s->num_tx_bpdu);
                 printf("Num TX TCN           %u\n", s->num_tx_tcn);
                 printf("  Num RX BPDU        %-23u ", s->num_rx_bpdu);
@@ -886,6 +891,9 @@ static int do_showport_fmt_plain(const CIST_PortStatus *s,
             break;
         case PARAM_BPDUGUARDERROR:
             printf("%s\n", BOOL_STR(s->bpdu_guard_error));
+            break;
+        case PARAM_BPDUFILTERPORT:
+            printf("%s\n", BOOL_STR(s->bpdu_filter_port));
             break;
         case PARAM_NETWORKPORT:
             printf("%s\n", BOOL_STR(s->network_port));
@@ -1640,6 +1648,17 @@ static int cmd_setportbpduguard(int argc, char *const *argv)
     return set_port_cfg(bpdu_guard_port, getyesno(argv[3], "yes", "no"));
 }
 
+static int cmd_setportbpdufilter(int argc, char *const *argv)
+{
+    int br_index = get_index(argv[1], "bridge");
+    if (0 > br_index)
+        return br_index;
+    int port_index = get_index(argv[2], "port");
+    if (0 > port_index)
+        return port_index;
+    return set_port_cfg(bpdu_filter_port, getyesno(argv[3], "yes", "no"));
+}
+
 static int cmd_setportnetwork(int argc, char *const *argv)
 {
     int br_index = get_index(argv[1], "bridge");
@@ -2243,6 +2262,8 @@ static const struct command commands[] =
      "<bridge> <port> {yes|no}", "Set port network state"},
     {3, 0, "setportdonttxmt", cmd_setportdonttxmt,
      "<bridge> <port> {yes|no}", "Disable/Enable sending BPDU"},
+    {3, 0, "setportbpdufilter", cmd_setportbpdufilter,
+     "<bridge> <port> {yes|no}", "Set BPDU filter state"},
 
     /* Other */
     {1, 0, "debuglevel", cmd_debuglevel, "<level>", "Level of verbosity"},

--- a/mstp.h
+++ b/mstp.h
@@ -477,6 +477,7 @@ typedef struct
     bool NetworkPort;
     bool BaInconsistent;
     bool dontTxmtBpdu;
+    bool bpduFilterPort;
 
     unsigned int rapidAgeingWhile;
     unsigned int brAssuRcvdInfoWhile;
@@ -494,6 +495,7 @@ typedef struct
     bool deleted;
 
     sysdep_if_data_t sysdeps;
+    unsigned int num_rx_bpdu_filtered;
     unsigned int num_rx_bpdu;
     unsigned int num_rx_tcn;
     unsigned int num_tx_bpdu;
@@ -700,8 +702,10 @@ typedef struct
     __u32 internal_port_path_cost; /* not in standard */
     bool bpdu_guard_port;
     bool bpdu_guard_error;
+    bool bpdu_filter_port;
     bool network_port;
     bool ba_inconsistent;
+    unsigned int num_rx_bpdu_filtered;
     unsigned int num_rx_bpdu;
     unsigned int num_rx_tcn;
     unsigned int num_tx_bpdu;
@@ -774,6 +778,9 @@ typedef struct
 
     bool dont_txmt;
     bool set_dont_txmt;
+
+    bool bpdu_filter_port;
+    bool set_bpdu_filter_port;
 } CIST_PortConfig;
 
 int MSTP_IN_set_cist_port_config(port_t *prt, CIST_PortConfig *cfg);

--- a/utils/bash_completion
+++ b/utils/bash_completion
@@ -16,8 +16,8 @@ _mstpctl()
                 setportautoedge setportp2p setportrestrrole setportrestrtcn \
                 setbpduguard settreeportprio settreeportcost showbridge \
                 showmstilist showmstconfid showvid2fid showfid2mstid showport \
-                showportdetail showtree showtreeport \
-                sethello setageing setportnetwork" -- "$cur" ) )
+                showportdetail showtree showtreeport sethello \
+                setageing setportnetwork setportbpdufilter" -- "$cur" ) )
             ;;
         2)
             case $command in
@@ -33,7 +33,8 @@ _mstpctl()
                 showport|showportdetail|showtreeport|showportpathcode|\
                 setportadminedge|setportautoedge|setportp2p|\
                 setportrestrrole|setportrestrtcn|portmcheck|\
-                settreeportprio|settreeportcost|setportnetwork)
+                settreeportprio|settreeportcost|setportnetwork|\
+                setportbpdufilter)
                     COMPREPLY=( $( compgen -W "$(for x in \
                         `ls /sys/class/net/${words[2]}/brif/`; do echo $x; \
                         done)" -- "$cur" ) )
@@ -45,8 +46,8 @@ _mstpctl()
             ;;
         4)
             case $command in
-                setportadminedge|setportautoedge|\
-                setportrestrrole|setportrestrtcn|setbpduguard|setportnetwork)
+                setportadminedge|setportautoedge|setportrestrrole|\
+                setportrestrtcn|setbpduguard|setportnetwork|setportbpdufilter)
                     COMPREPLY=( $( compgen -W 'yes no' -- "$cur" ) )
                     ;;
                 setportp2p)

--- a/utils/ifupdown.sh.in
+++ b/utils/ifupdown.sh.in
@@ -208,6 +208,17 @@ if [ "$MODE" = 'start' ]; then
     done
   fi
 
+  if [ "$IF_MSTPCTL_PORTBPDUFILTER" ]; then
+    portbpdufilters="$(echo "$IF_MSTPCTL_PORTBPDUFILTER" | tr '\n' ' ' | tr -s ' ')"
+    for portbpdufilter in $portbpdufilters; do
+      port="$(echo "$portbpdufilter" | cut -d '=' -f1)"
+      bpdufilter="$(echo "$portbpdufilter" | cut -d '=' -f2)"
+      if [ -n "$port" ] && [ -n "$bpdufilter" ]; then
+        "$mstpctl" setportbpdufilter "$IFACE" "$port" "$bpdufilter"
+      fi
+    done
+  fi
+
   if [ "$IF_MSTPCTL_TREEPORTPRIO" ]; then
     treeportprios="$(echo "$IF_MSTPCTL_TREEPORTPRIO" | tr '\n' ' ' | tr -s ' ')"
     for treeportprio in $treeportprios; do

--- a/utils/mstpctl-utils-interfaces.5
+++ b/utils/mstpctl-utils-interfaces.5
@@ -38,7 +38,7 @@ auto br0
 iface br0 inet static
     address 12.0.0.3
     netmask 255.255.255.0
-    mstpctl_ports swp1 swp2 swp3
+    mstpctl_ports swp1 swp2 swp3 swp4
     mstpctl_stp on
     mstpctl_maxwait auto
     mstpctl_maxage 20
@@ -47,16 +47,17 @@ iface br0 inet static
     mstpctl_txholdcount 6
     mstpctl_forcevers rstp
     mstpctl_portpathcost swp1=0 swp2=0
-    mstpctl_portadminedge swp1=no swp2=no
+    mstpctl_portadminedge swp1=no swp2=no swp4=yes
     mstpctl_portautoedge swp1=yes swp2=yes
     mstpctl_portp2p swp1=no swp2=no
     mstpctl_portrestrrole swp1=no swp2=no
-    mstpctl_bpduguard swp1=no swp2=no
+    mstpctl_bpduguard swp1=no swp2=no swp4=yes
     mstpctl_portrestrtcn swp1=no swp2=no
     mstpctl_treeprio 8
     mstpctl_treeportprio swp3=8
     mstpctl_hello 2
     mstpctl_portnetwork swp1=no
+    mstpctl_portbpdufilter swp4=yes
 
 .EE
 .SH IFACE OPTIONS
@@ -143,6 +144,10 @@ sets the ethernet (MAC) address ageing \fItime\fP, in seconds. Used only when pr
 .TP
 .BI mstpctl_portnetwork " port yes|no"
 Enables/disables the bridge assurance capability for a \fIport\fP,
+default is no.
+.TP
+.BI mstpctl_portbpdufilter " port yes|no"
+Enables/disables the bridge BPDU filter capability for a \fIport\fP,
 default is no.
 .RE
 .SH FILES

--- a/utils/mstpctl.8
+++ b/utils/mstpctl.8
@@ -82,6 +82,11 @@ sets the ethernet (MAC) address ageing <time>, in seconds, for the <bridge>. Use
 Enables/disables the bridge assurance capability for a <port> in <bridge>,
 default is no.
 
+.B mstpctl setportbpdufilter <bridge> <port> {yes|no}
+Enables/disables the BPDU filter capability for a port <port> in
+bridge <bridge>, i.e. discard any ingress BPDUs and do not issue any
+BPDUs for this port. The default is no.
+
 .SH SPANNING TREE PROTOCOL SHOW COMMANDS
 .B mstpctl showbridge [<bridge>]
 will show information of the <bridge>'s CIST instance. If <bridge> parameter is omitted - shows info for all bridges.


### PR DESCRIPTION
Add support for a "BPDU Port Filter" option ("setportbpdufilter"),
i.e. discard BPDUs on ingress and do not issue BPDUs. Further add a
counter that indicates the number of received BPDUs that have been
discarded.