### PR TITLE
get_id: id overflow fixed

### DIFF
--- a/ctl_main.c
+++ b/ctl_main.c
@@ -56,10 +56,8 @@ static inline int get_index(const char *ifname, const char *doc)
 
 static inline int get_id(const char *str, const char *doc, unsigned int max_id)
 {
-    int id = strtol(str, NULL, 10);
-    if((0 > id) || (max_id < id)
-       || ((0 == id) && ('0' != str[0]))
-      )
+    unsigned long id = strtoul(str, NULL, 10);
+    if((max_id < id) || ((0 == id) && ('0' != str[0])))
     {
         fprintf(stderr, "Bad %s %s\n", doc, str);
         return -1;


### PR DESCRIPTION
id values in range [LONG_MIN + 1; LONG_MIN + max_id] were converted to valid id. 
Then:
zolotarev@localhost: ~ / mstpd> ./mstpctl createtree br0 -- -9223372036854771714
2019-01-23 16:29:48 MSTP_OUT_set_state: br0:enp7s0:4094 entering blocking state
2019-01-23 16:29:48 MSTP_OUT_flush_all_fids: br0:enp7s0:4094 Flushing forwarding database
Now:
zolotarev@localhost: ~ / mstpd> ./mstpctl createtree br0 -- -9223372036854771714
Bad mstid -9223372036854771714
