### PR TITLE
treewide: allow room for null-char in strncpy()

### DIFF
--- a/mstp.c
+++ b/mstp.c
@@ -1615,7 +1615,7 @@ void MSTP_IN_set_mst_config_id(bridge_t *br, __u16 revision, __u8 *name)
         memset(br->MstConfigId.s.configuration_name, 0,
                sizeof(br->MstConfigId.s.configuration_name));
         strncpy((char *)br->MstConfigId.s.configuration_name, (char *)name,
-                sizeof(br->MstConfigId.s.configuration_name));
+                sizeof(br->MstConfigId.s.configuration_name) - 1);
         br_state_machines_begin(br);
     }
 }

--- a/netif_utils.c
+++ b/netif_utils.c
@@ -60,7 +60,7 @@ int get_hwaddr(char *ifname, __u8 *hwaddr)
 {
     struct ifreq ifr;
     memset(&ifr, 0, sizeof(ifr));
-    strncpy(ifr.ifr_name, ifname, IFNAMSIZ);
+    strncpy(ifr.ifr_name, ifname, IFNAMSIZ - 1);
     if(0 > ioctl(netsock, SIOCGIFHWADDR, &ifr))
     {
         ERROR("%s: get hw address failed: %m", ifname);
@@ -74,7 +74,7 @@ int get_flags(char *ifname)
 {
     struct ifreq ifr;
     memset(&ifr, 0, sizeof(ifr));
-    strncpy(ifr.ifr_name, ifname, IFNAMSIZ);
+    strncpy(ifr.ifr_name, ifname, IFNAMSIZ - 1);
     if(0 > ioctl(netsock, SIOCGIFFLAGS, &ifr))
     {
         ERROR("%s: get interface flags failed: %m", ifname);
@@ -94,7 +94,7 @@ int if_shutdown(char *ifname)
         return -1;
     }
     ifr.ifr_flags &= ~IFF_UP;
-    strncpy(ifr.ifr_name, ifname, IFNAMSIZ);
+    strncpy(ifr.ifr_name, ifname, IFNAMSIZ - 1);
     if(0 > ioctl(netsock, SIOCSIFFLAGS, &ifr))
     {
         ERROR("%s: set if_down flag failed: %m", ifname);
@@ -107,7 +107,7 @@ int ethtool_get_speed_duplex(char *ifname, int *speed, int *duplex)
 {
     struct ifreq ifr;
     memset(&ifr, 0, sizeof(ifr));
-    strncpy(ifr.ifr_name, ifname, IFNAMSIZ);
+    strncpy(ifr.ifr_name, ifname, IFNAMSIZ - 1);
     struct ethtool_cmd ecmd;
 
     ecmd.cmd = ETHTOOL_GSET;


### PR DESCRIPTION
strncpy() is not safe as it can put `len` elements of a string and discard
the null-char if there isn't any room left.

An alternative option would be to use `strlcpy()` but that function may not
be portable to all libc implementations.
So, just reduce the `len` by 1 byte to allow room for null-char.

This was reported via string-fortify headers.

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>