### PR TITLE
Add systemd unit file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@
 /utils/ifupdown.sh.tmp
 /utils/mstp_config_bridge
 /utils/mstp_config_bridge.tmp
+/utils/mstpd.service
+/utils/mstpd.service.tmp
 
 # autotools files
 /m4/lt*.m4

--- a/Makefile.am
+++ b/Makefile.am
@@ -16,7 +16,7 @@ if ENABLE_DEVEL
 endif
 mstpctl_CFLAGS = $(mstpd_CFLAGS)
 
-all-local: bridge-stp utils/ifupdown.sh utils/mstp_config_bridge
+all-local: bridge-stp utils/ifupdown.sh utils/mstp_config_bridge utils/mstpd.service
 
 utilsdir=$(libexecdir)/mstpctl-utils
 
@@ -34,13 +34,14 @@ mstpd_CFLAGS += -DMSTPD_PID_FILE='"$(mstpdpidfile)"'
 # See https://www.gnu.org/savannah-checkouts/gnu/autoconf/manual/autoconf-2.69/html_node/Installation-Directory-Variables.html#index-sysconfdir-188
 populate_template = sed \
 	-e 's|@mstpdfile[@]|$(mstpdfile)|g' \
+	-e 's|@mstpdpidfile[@]|$(mstpdpidfile)|g' \
 	-e 's|@mstpctlfile[@]|$(mstpctlfile)|g' \
 	-e 's|@bridgestpconffile[@]|$(bridgestpconffile)|g' \
 	-e 's|@ifupdownfile[@]|$(ifupdownfile)|g' \
 	-e 's|@utilsfuncfile[@]|$(utilsfuncfile)|g' \
 	-e 's|@configbridgefile[@]|$(configbridgefile)|g' \
 	-e 's|@ifqueryfile[@]|$(ifqueryfile)|g'
-bridge-stp utils/ifupdown.sh utils/mstp_config_bridge: Makefile
+bridge-stp utils/ifupdown.sh utils/mstp_config_bridge utils/mstpd.service: Makefile
 	rm -f $@ $@.tmp
 	mkdir -p $(@D)
 	srcdir=''; test -f ./$@.in || srcdir="$(srcdir)/"; \
@@ -55,6 +56,7 @@ sbindest=$(DESTDIR)$(sbindir)
 utilsdest=$(DESTDIR)$(utilsdir)
 etcdest=$(DESTDIR)$(sysconfdir)
 bashcompdest=$(DESTDIR)$(bashcompletiondir)
+systemdunitdest=$(DESTDIR)$(systemdunitdir)
 man5dest=$(DESTDIR)$(mandir)/man5
 man8dest=$(DESTDIR)$(mandir)/man8
 docdest=$(DESTDIR)$(docdir)
@@ -81,6 +83,10 @@ install-data-hook:
 	fi
 	mkdir -pv $(bashcompdest)
 	install -m 644 $(srcdir)/utils/bash_completion $(bashcompdest)/mstpctl
+	if [ -n "$(systemdunitdir)" ]; then \
+	  mkdir -pv $(systemdunitdest) ; \
+	  install -m 644 $(srcdir)/utils/mstpd.service $(systemdunitdest) ; \
+	fi
 	mkdir -pv $(man8dest)
 	install -m 644 $(srcdir)/utils/mstpctl.8 $(man8dest)/mstpctl.8
 	gzip -f $(man8dest)/mstpctl.8

--- a/configure.ac
+++ b/configure.ac
@@ -41,6 +41,8 @@ AC_PROG_CC
 m4_ifdef([AM_PROG_AR], [AM_PROG_AR])
 LT_INIT
 
+PKG_PROG_PKG_CONFIG
+
 # Optional building of examples
 AC_ARG_ENABLE([devel],
 	[AC_HELP_STRING([--enable-devel], [build devel mode])],
@@ -56,6 +58,14 @@ AS_IF([test "x$with_bashcompletiondir" = "xdefault"],
      [AC_SUBST([bashcompletiondir], [${sysconfdir}/bash_completion.d])])
 AS_IF([test "x$with_bashcompletiondir" != "xdefault"],
       [AC_SUBST([bashcompletiondir], [$with_bashcompletiondir])])
+
+AC_ARG_WITH([systemdunitdir],
+     [AS_HELP_STRING([--with-systemunitdir=DIR], [Directory for systemd unit files.])],,
+     [with_systemdunitdir=default])
+AS_IF([test "x$with_systemdunitdir" = "xdefault"],
+     [AC_SUBST([systemdunitdir], [$($PKG_CONFIG --variable=systemdsystemunitdir systemd 2> /dev/null)])])
+AS_IF([test "x$with_systemdunitdir" != "xdefault"],
+      [AC_SUBST([systemdunitdir], [$with_systemdunitdir])])
 
 # Define PACKAGE_BUILD
 PACKAGE_BUILD=`git log --pretty=format:'%h' -n 1`

--- a/utils/mstpd.service.in
+++ b/utils/mstpd.service.in
@@ -1,0 +1,14 @@
+[Unit]
+Description=MSTP daemon
+Before=network.target
+
+[Service]
+Type=forking
+ExecStart=@mstpdfile@
+PIDFile=@mstpdpidfile@
+Restart=on-failure
+PrivateTmp=yes
+ProtectHome=yes
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
This is a proposition to add a systemd unit. I still needs to test it (too late now).

Related to Debian, I would suggest Debian ships `/etc/bridge-stp.conf` with `MANAGE_STPD` sets to `n`.