### PR TITLE
ifquery: Use versioned python shebang and fix flake8 warnings

### DIFF
--- a/rpm.spec
+++ b/rpm.spec
@@ -34,6 +34,12 @@ make %{?_smp_mflags}
 rm -rf %{buildroot}
 make install DESTDIR=%{buildroot}
 
+# RHEL7/CentOS7 still permits #!/usr/bin/python in scripts.  Other supported
+# RPM-based distros/versions require #!/usr/bin/python3 in all scripts.
+%if !0%{?rhel} || 0%{?rhel} >= 8
+sed -i -e 's|#!/usr/bin/python|#!/usr/bin/python3|g' %{buildroot}/%{_libexecdir}/mstpctl-utils/ifquery
+%endif
+
 sed -i -e 's|/etc/network/interfaces|/etc/sysconfig/network-scripts/bridge-stp|g' %{buildroot}/%{_libexecdir}/mstpctl-utils/ifquery
 sed -i -e 's|/etc/network/interfaces|/etc/sysconfig/network-scripts/bridge-stp|g' %{buildroot}/%{_libexecdir}/mstpctl-utils/mstp_config_bridge
 

--- a/utils/ifquery
+++ b/utils/ifquery
@@ -4,29 +4,31 @@
 import sys
 import glob
 
+
 def parse_config(interfaces_file, interface):
     f = open(interfaces_file)
     intf = ''
     for line in f:
         str = line.strip().split(' ')
         len_str = len(str)
-        if 2 > len_str :
+        if 2 > len_str:
             continue
-        if str[0].startswith('#') :
+        if str[0].startswith('#'):
             continue
         # Check if the source <file> keyword is present and extract the file
-        if str[0] == 'source' :
+        if str[0] == 'source':
             for sfile in glob.glob(str[1]):
                 parse_config(sfile, interface)
-        if str[0] == 'iface' :
+        if str[0] == 'iface':
             intf = str[1]
             continue
         # Check if this is the relevant interface.
-        if intf != interface :
+        if intf != interface:
             continue
         # Print configuration.
         print(str[0]+": "+" ".join(str[1:]))
     f.close()
     return
+
 
 parse_config('/etc/network/interfaces', sys.argv[1])


### PR DESCRIPTION
`utils/ifquery` is used by rpm.spec for mstpd configuration on RPM-based systems.  `rpmbuild` now requires all python shebangs to be versioned ("python2" or "python3").

While I'm changing things in that file, the `flake8` python linter complains about some minor formatting issues, so I've cleaned those up.