### PR TITLE
RFC: add a driver setting MST per port state as linux per vlan port state

### DIFF
--- a/libnetlink.c
+++ b/libnetlink.c
@@ -611,6 +611,37 @@ int rta_addattr_l(struct rtattr *rta, int maxlen, int type,
 	return 0;
 }
 
+int rta_addattr8(struct rtattr *rta, int maxlen, int type, __u8 data)
+{
+	return rta_addattr_l(rta, maxlen, type, &data, sizeof(__u8));
+}
+
+int rta_addattr16(struct rtattr *rta, int maxlen, int type, __u16 data)
+{
+	return rta_addattr_l(rta, maxlen, type, &data, sizeof(__u16));
+}
+
+int rta_addattr64(struct rtattr *rta, int maxlen, int type, __u64 data)
+{
+	return rta_addattr_l(rta, maxlen, type, &data, sizeof(__u64));
+}
+
+struct rtattr *rta_nest(struct rtattr *rta, int maxlen, int type)
+{
+	struct rtattr *nest = RTA_TAIL(rta);
+
+	rta_addattr_l(rta, maxlen, type, NULL, 0);
+
+	return nest;
+}
+
+int rta_nest_end(struct rtattr *rta, struct rtattr *nest)
+{
+	nest->rta_len = (void *)RTA_TAIL(rta) - (void *)nest;
+
+	return rta->rta_len;
+}
+
 int parse_rtattr(struct rtattr *tb[], int max, struct rtattr *rta, int len)
 {
 	memset(tb, 0, sizeof(struct rtattr *) * (max + 1));

--- a/libnetlink.c
+++ b/libnetlink.c
@@ -631,6 +631,7 @@ struct rtattr *rta_nest(struct rtattr *rta, int maxlen, int type)
 	struct rtattr *nest = RTA_TAIL(rta);
 
 	rta_addattr_l(rta, maxlen, type, NULL, 0);
+	nest->rta_type |= NLA_F_NESTED;
 
 	return nest;
 }

--- a/libnetlink.h
+++ b/libnetlink.h
@@ -35,13 +35,23 @@ int addattr32(struct nlmsghdr *n, int maxlen, int type, __u32 data);
 int addattr_l(struct nlmsghdr *n, int maxlen, int type, const void *data,
               int alen);
 int addraw_l(struct nlmsghdr *n, int maxlen, const void *data, int len);
+int rta_addattr8(struct rtattr *rta, int maxlen, int type, __u8 data);
+int rta_addattr16(struct rtattr *rta, int maxlen, int type, __u16 data);
 int rta_addattr32(struct rtattr *rta, int maxlen, int type, __u32 data);
+int rta_addattr64(struct rtattr *rta, int maxlen, int type, __u64 data);
 int rta_addattr_l(struct rtattr *rta, int maxlen, int type,
                          const void *data, int alen);
 
 int parse_rtattr(struct rtattr *tb[], int max, struct rtattr *rta, int len);
 int parse_rtattr_byindex(struct rtattr *tb[], int max, struct rtattr *rta,
                          int len);
+
+struct rtattr *rta_nest(struct rtattr *rta, int maxlen, int type);
+int rta_nest_end(struct rtattr *rta, struct rtattr *nest);
+
+#define RTA_TAIL(rta) \
+		((struct rtattr *) (((void *) (rta)) + \
+				    RTA_ALIGN((rta)->rta_len)))
 
 #define parse_rtattr_nested(tb, max, rta) \
     (parse_rtattr((tb), (max), RTA_DATA(rta), RTA_PAYLOAD(rta)))

--- a/linux_pvstate/driver_deps.c
+++ b/linux_pvstate/driver_deps.c
@@ -1,0 +1,167 @@
+/*
+ * driver_deps.c    Propagate MSTI port states to Linux Per VLAN STP states
+ *
+ *  This program is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU General Public License
+ *  as published by the Free Software Foundation; either version
+ *  2 of the License, or (at your option) any later version.
+ *
+ * Authors: Vitalii Demianets <dvitasgs@gmail.com>
+ * Authors: Jonas Gorski <jonas.gorski@bisdn.de> -- Set Linux Per VLAN state
+ */
+
+#include <fcntl.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <string.h>
+#include <asm/byteorder.h>
+
+#include <linux/if_bridge.h>
+
+#include "bridge_ctl.h"
+#include "libnetlink.h"
+#include "log.h"
+#include "mstp.h"
+
+static int br_set_vlan_state(struct rtnl_handle *rth, unsigned ifindex, __u16 vid, __u8 state)
+{
+    struct
+    {
+        struct nlmsghdr n;
+        struct br_vlan_msg bvm;
+        char buf[256];
+    } req;
+    char entry_buf[256];
+    struct rtattr *rta = (void *)entry_buf;
+    struct bridge_vlan_info vlan_info;
+    struct rtattr *nest;
+
+    memset(&req, 0, sizeof(req));
+
+    req.n.nlmsg_len = NLMSG_LENGTH(sizeof(struct br_vlan_msg));
+    req.n.nlmsg_flags = NLM_F_REQUEST | NLM_F_REPLACE;
+    req.n.nlmsg_type = RTM_NEWVLAN;
+    req.bvm.family = AF_BRIDGE;
+    req.bvm.ifindex = ifindex;
+
+    rta->rta_type = BRIDGE_VLANDB_ENTRY;
+    rta->rta_len = RTA_LENGTH(0);
+
+    vlan_info.vid = vid;
+    vlan_info.flags = BRIDGE_VLAN_INFO_ONLY_OPTS;
+
+    nest = rta_nest(rta, sizeof(entry_buf), BRIDGE_VLANDB_ENTRY);
+    rta_addattr_l(rta, sizeof(entry_buf), BRIDGE_VLANDB_ENTRY_INFO, &vlan_info, sizeof(vlan_info));
+    rta_addattr8(rta, sizeof(entry_buf), BRIDGE_VLANDB_ENTRY_STATE, state);
+
+    rta_nest_end(rta, nest);
+
+    addraw_l(&req.n, sizeof(req.buf), RTA_DATA(rta), RTA_PAYLOAD(rta));
+
+    return rtnl_talk(rth, &req.n, 0, 0, NULL, NULL, NULL);
+}
+
+
+/* Initialize driver objects & states */
+int driver_mstp_init()
+{
+    return 0;
+}
+
+/* Cleanup driver objects & states */
+void driver_mstp_fini()
+{
+
+}
+
+/* Driver hook that is called before a bridge is created */
+bool driver_create_bridge(bridge_t *br, __u8 *macaddr)
+{
+    return true;
+}
+
+/* Driver hook that is called before a port is created */
+bool driver_create_port(port_t *prt, __u16 portno)
+{
+    return true;
+}
+
+/* Driver hook that is called when a bridge is deleted */
+void driver_delete_bridge(bridge_t *br)
+{
+
+}
+
+/* Driver hook that is called when a port is deleted */
+void driver_delete_port(port_t *prt)
+{
+
+}
+
+
+/*
+ * Set new state (BR_STATE_xxx) for the given port and MSTI.
+ * Return new actual state (BR_STATE_xxx) from driver.
+ */
+int driver_set_new_state(per_tree_port_t *ptp, int new_state)
+{
+    port_t *prt = ptp->port;
+    bridge_t *br = prt->bridge;
+    int i;
+
+    /* CIST will already be handled by common code */
+    if(0 == ptp->MSTID)
+        return new_state;
+
+    /* There is no MSTID -> VID mapping, so for now check all possible VIDs.
+     * This is probably not the most efficient, but at least a constant, and
+     * checking 4k should not take that long.
+     *
+     * The mapping is VID -> FID -> MSTID, so let's go that way.
+     */
+    for (i = 1; i <= MAX_VID; i++)
+    {
+        __u16 fid = br->vid2fid[i];
+
+        if (br->fid2mstid[fid] != ptp->MSTID)
+            continue;
+
+        if (0 > br_set_vlan_state(&rth_state, prt->sysdeps.if_index, i, new_state))
+            ERROR_MSTINAME(br, prt, ptp, "Couldn't set kernel if %i vid %i bridge state %i",
+                          prt->sysdeps.if_index, i, new_state);
+    }
+
+    return new_state;
+}
+
+bool driver_create_msti(bridge_t *br, __u16 mstid)
+{
+    /* TODO: send "create msti" command to driver */
+    return true;
+}
+
+bool driver_delete_msti(bridge_t *br, __u16 mstid)
+{
+    /* TODO: send "delete msti" command to driver */
+    return true;
+}
+
+void driver_flush_all_fids(per_tree_port_t *ptp)
+{
+    /* TODO: do real flushing.
+     * Make it asynchronous, with completion function calling
+     * MSTP_IN_all_fids_flushed(ptp)
+     */
+    MSTP_IN_all_fids_flushed(ptp);
+}
+
+/*
+ * Set new ageing time (in seconds) for the port.
+ * Return new actual ageing time from driver (the ageing timer granularity
+ *  in the hardware can be more than 1 sec)
+ */
+unsigned int driver_set_ageing_time(port_t *prt, unsigned int ageingTime)
+{
+    /* TODO: do set new ageing time */
+    return ageingTime;
+}


### PR DESCRIPTION
Since release 5.6 Linux supports a per VLAN STP state in addition to the bridge port stp state.

This driver attempts to make use of it to propagate the MSTI port states to their appropriate VLAN STP states using the new netlink messages for this.

Our understanding of MSTP is currently very vague, and we are trying to understand how this work and whether MSTPd does the right thing, and if this implementation is enough, or more work is needed. 

Some notes for the implementation:

* I imported two commits for libnetlink from iproute2, where it seems to have originated. I kept all authorship intact, and added my SoB since I slightly modified them so they apply.
* We verified that setting the per VLAN STP state does work, but of course checking isn't easy since there are no userspace utilities yet to show the per VLAN STP states. We have an internal patched iproute2 bridge utility for that, but it's far from an upstreamable state yet.
* I haven't found an easy way to find out the VLANs of a MSTI, so for now I just iterate over all possible VIDs and check if VID -> FID -> MSTID matches the current MSTI. Not efficient, but at least a fixed runtime.
* While it is possible to set the STP state of VLAN ranges and multiple VLANs at once, since the kernel will discard the message on the first invalid VLAN of a port, sending individual messages is (probably) safer.
* AFAICT the way the bridge port STP state and the VLAN STP state interact is that the "lower" of the two wins. E.g. only if both are in forwarding, the vlan for the port will forward. So setting the bridge port STP state to blocked will block for all VLANs, regardless of their per VLAN STP states.

Now to the RFC part:

Currently MSTPd sets the CIST state as the bridge port STP state. This e.g. results in all VLANs being blocked if the CIST says the port is blocked, even if other MSTIs say the port should forward for those VLANs.

Does this make sense? Can this even happen? Or should the CIST state only being applied to the VLANs not assigned to any MSTIs? If the latter, then MSTPd would need to be changed to not set the CIST state as the bridge port stp state.

Is it correct that MSTP(d) expects a VLAN to be present/available on all bridge interfaces? If so, then we need to make MSTPd listen for VLANDB entries and dynamically apply STP state if they get created, else STP state might get lost if VLANs get created after MSTPd applied the VLAN state of a MSTI.

And more a understanding question of MSTP, since AFAICT all bridges in a MST are treated as one bridge for the CIST, what does that mean for the CIST port states within the region? Are they all forwarding, or should they be also be set to some non-looping state?

Looking at figure 13-11 of 802.11Q-2018 (p. 496), there on the CIST the port of bridge 84 to LAN J (to bridge 97) is blocked, but in the MSTI topology it is forwarding.

If this means that the MTSI should be in forwarding, then this answers the first question as in MSTPd should not set the CIST state to the bridge port STP state, but the VLAN STP states that are part of the CIST / not assigned to a MSTI.