### PR TITLE
build: move -Werror flag under --enable-devel opt

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -9,10 +9,10 @@ mstpctl_SOURCES = \
 	ctl_main.c ctl_socket_client.c
 
 mstpd_CFLAGS = \
-	-Os -Wall -Werror -D_REENTRANT -D__LINUX__ -I. \
+	-Os -Wall -D_REENTRANT -D__LINUX__ -I. \
 	-D_GNU_SOURCE
 if ENABLE_DEVEL
-  mstpd_CFLAGS += -g3 -O0
+  mstpd_CFLAGS += -g3 -O0 -Werror
 endif
 mstpctl_CFLAGS = $(mstpd_CFLAGS)
 


### PR DESCRIPTION
This change disables the -Werror flag under normal build. When updating
compilers, new warnings get enabled by default.
We will do this only during CI where the --enable-devel flag will be set.

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>