### PR TITLE
libnetlink changes required for any VLAN/MSTI state solution

### DIFF
--- a/libnetlink.c
+++ b/libnetlink.c
@@ -611,6 +611,37 @@ int rta_addattr_l(struct rtattr *rta, int maxlen, int type,
 	return 0;
 }
 
+int rta_addattr8(struct rtattr *rta, int maxlen, int type, __u8 data)
+{
+	return rta_addattr_l(rta, maxlen, type, &data, sizeof(__u8));
+}
+
+int rta_addattr16(struct rtattr *rta, int maxlen, int type, __u16 data)
+{
+	return rta_addattr_l(rta, maxlen, type, &data, sizeof(__u16));
+}
+
+int rta_addattr64(struct rtattr *rta, int maxlen, int type, __u64 data)
+{
+	return rta_addattr_l(rta, maxlen, type, &data, sizeof(__u64));
+}
+
+struct rtattr *rta_nest(struct rtattr *rta, int maxlen, int type)
+{
+	struct rtattr *nest = RTA_TAIL(rta);
+
+	rta_addattr_l(rta, maxlen, type, NULL, 0);
+
+	return nest;
+}
+
+int rta_nest_end(struct rtattr *rta, struct rtattr *nest)
+{
+	nest->rta_len = (void *)RTA_TAIL(rta) - (void *)nest;
+
+	return rta->rta_len;
+}
+
 int parse_rtattr(struct rtattr *tb[], int max, struct rtattr *rta, int len)
 {
 	memset(tb, 0, sizeof(struct rtattr *) * (max + 1));

--- a/libnetlink.c
+++ b/libnetlink.c
@@ -631,6 +631,7 @@ struct rtattr *rta_nest(struct rtattr *rta, int maxlen, int type)
 	struct rtattr *nest = RTA_TAIL(rta);
 
 	rta_addattr_l(rta, maxlen, type, NULL, 0);
+	nest->rta_type |= NLA_F_NESTED;
 
 	return nest;
 }

--- a/libnetlink.h
+++ b/libnetlink.h
@@ -35,13 +35,23 @@ int addattr32(struct nlmsghdr *n, int maxlen, int type, __u32 data);
 int addattr_l(struct nlmsghdr *n, int maxlen, int type, const void *data,
               int alen);
 int addraw_l(struct nlmsghdr *n, int maxlen, const void *data, int len);
+int rta_addattr8(struct rtattr *rta, int maxlen, int type, __u8 data);
+int rta_addattr16(struct rtattr *rta, int maxlen, int type, __u16 data);
 int rta_addattr32(struct rtattr *rta, int maxlen, int type, __u32 data);
+int rta_addattr64(struct rtattr *rta, int maxlen, int type, __u64 data);
 int rta_addattr_l(struct rtattr *rta, int maxlen, int type,
                          const void *data, int alen);
 
 int parse_rtattr(struct rtattr *tb[], int max, struct rtattr *rta, int len);
 int parse_rtattr_byindex(struct rtattr *tb[], int max, struct rtattr *rta,
                          int len);
+
+struct rtattr *rta_nest(struct rtattr *rta, int maxlen, int type);
+int rta_nest_end(struct rtattr *rta, struct rtattr *nest);
+
+#define RTA_TAIL(rta) \
+		((struct rtattr *) (((void *) (rta)) + \
+				    RTA_ALIGN((rta)->rta_len)))
 
 #define parse_rtattr_nested(tb, max, rta) \
     (parse_rtattr((tb), (max), RTA_DATA(rta), RTA_PAYLOAD(rta)))


### PR DESCRIPTION
As requested in #112, these two patches that come from #103 can already be applied to support any future solution and experiments in setting the state for either a VLAN or an MSTI in Linux.