### PR TITLE
make libnetlink.h standalone

### DIFF
--- a/libnetlink.h
+++ b/libnetlink.h
@@ -1,9 +1,11 @@
 #ifndef __LIBNETLINK_H__
 #define __LIBNETLINK_H__
 
+#include <stdio.h>
 #include <asm/types.h>
 #include <linux/netlink.h>
 #include <linux/rtnetlink.h>
+#include <sys/types.h>
 
 struct rtnl_handle
 {


### PR DESCRIPTION
The header file uses certain data types for which it doesn't include
header files and relies and the source code to provie them.

This is required for the use of libnetlink.h in #112.