### PR TITLE
build with Ubuntu 20.04

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on: [ push, pull_request ]
 
 jobs:
   linux:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
     - name: build


### PR DESCRIPTION
Any changes that rely on new kernel features require either to switch to new kernel headers in the build system or to add the kernel headers to the project. I vote for using the distribution kernel headers rather than bundling them.

It provides better support for experimental builds on systems with experimental kernels used e.g. to test experimental features in #112.