### PR TITLE
bdep on ifupdown

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+mstpd (0.0.9~bpo10+1) buster-backports; urgency=medium
+
+  * Built for buster-backports.
+
+ -- Matthias Förste <foerste@schlittermann.de>  Wed, 21 Apr 2021 12:17:18 +0200
+
 mstpd (0.0.9) unstable; urgency=medium
 
   * Handle increasing/decreasing fdelay and maxage in sync in ifcfg files.

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: mstpd
 Section: net
 Priority: optional
 Maintainer: Vitalii Demianets <vitalii@orsoc.se>
-Build-Depends: debhelper (>=9), dh-autoreconf
+Build-Depends: debhelper (>=9), dh-autoreconf, ifupdown
 Standards-Version: 3.9.8
 Homepage: https://github.com/mstpd/mstpd
 Vcs-Git: https://github.com/mstpd/mstpd.git


### PR DESCRIPTION
because the Makefile wont install ifupdown hooks if hook dirs are
missing