### PR TITLE
utils/ifquery: drop python2 support

### DIFF
--- a/rpm.spec
+++ b/rpm.spec
@@ -34,12 +34,6 @@ make %{?_smp_mflags}
 rm -rf %{buildroot}
 make install DESTDIR=%{buildroot}
 
-# RHEL7/CentOS7 still permits #!/usr/bin/python in scripts.  Other supported
-# RPM-based distros/versions require #!/usr/bin/python3 in all scripts.
-%if !0%{?rhel} || 0%{?rhel} >= 8
-sed -i -e 's|#!/usr/bin/python|#!/usr/bin/python3|g' %{buildroot}/%{_libexecdir}/mstpctl-utils/ifquery
-%endif
-
 sed -i -e 's|/etc/network/interfaces|/etc/sysconfig/network-scripts/bridge-stp|g' %{buildroot}/%{_libexecdir}/mstpctl-utils/ifquery
 sed -i -e 's|/etc/network/interfaces|/etc/sysconfig/network-scripts/bridge-stp|g' %{buildroot}/%{_libexecdir}/mstpctl-utils/mstp_config_bridge
 

--- a/utils/ifquery
+++ b/utils/ifquery
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 # Crudely emulate ifquery on systems that don't have it.
 
 import sys
@@ -26,7 +26,7 @@ def parse_config(interfaces_file, interface):
         if intf != interface:
             continue
         # Print configuration.
-        print(str[0]+": "+" ".join(str[1:]))
+        print((str[0]+": "+" ".join(str[1:])))
     f.close()
     return
 


### PR DESCRIPTION
* python2 is not maintained anymore and all scripts using it should be
  updated to python3
* ran 2to3 for utils/ifquery and added python3 shebang
* removed python3 sed from rpm.spec

Signed-off-by: Jan Klare <jan.klare@bisdn.de>