### PR TITLE
rpm.spec: Fix mock build, requires and quoting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@
 /utils/mstp_config_bridge.tmp
 /utils/mstpd.service
 /utils/mstpd.service.tmp
+/utils/nm-dispatcher
+/utils/nm-dispatcher.tmp
 
 # autotools files
 /m4/lt*.m4

--- a/Makefile.am
+++ b/Makefile.am
@@ -21,11 +21,11 @@ endif
 mstpctl_CFLAGS = $(mstpd_CFLAGS)
 
 EXTRA_DIST = bridge-stp.in utils/ifupdown.sh.in utils/mstp_config_bridge.in \
-	utils/mstpd.service.in utils/bash_completion \
-	README.md README.VLANs.md rpm.spec autogen.sh
+	utils/mstpd.service.in utils/bash_completion utils/nm-dispatcher.in \
+	README.md README.VLANs.md mstpd.spec autogen.sh
 
 CLEANFILES = bridge-stp utils/ifupdown.sh utils/mstp_config_bridge \
-	utils/mstpd.service
+	utils/mstpd.service utils/nm-dispatcher
 dist_utilsexec_SCRIPTS = utils/ifquery
 dist_doc_DATA = LICENSE
 utilsexec_SCRIPTS = utils/ifupdown.sh utils/mstp_config_bridge
@@ -38,12 +38,15 @@ AM_DISTCHECK_CONFIGURE_FLAGS = --exec_prefix=$$dc_install_base \
 	--libexecdir=$$dc_install_base/lib \
 	--with-systemdunitdir=$$dc_install_base/usr/lib/systemd/system
 
-all-local: bridge-stp utils/ifupdown.sh utils/mstp_config_bridge utils/mstpd.service
+all-local: bridge-stp utils/ifupdown.sh utils/mstp_config_bridge \
+	utils/mstpd.service utils/nm-dispatcher
 
 utilsexecdir=$(libexecdir)/mstpctl-utils
+nmlibdir=$(prefix)/lib/NetworkManager/dispatcher.d
 
 mstpdfile=$(sbindir)/mstpd
 mstpctlfile=$(sbindir)/mstpctl
+bridgestpfile=$(sbindir)/bridge-stp
 mstpdpidfile=$(localstatedir)/run/mstpd.pid
 bridgestpconffile=$(sysconfdir)/bridge-stp.conf
 ifupdownfile=$(utilsexecdir)/ifupdown.sh
@@ -56,6 +59,7 @@ mstpd_CFLAGS += -DMSTPD_PID_FILE='"$(mstpdpidfile)"'
 # See https://www.gnu.org/savannah-checkouts/gnu/autoconf/manual/autoconf-2.69/html_node/Installation-Directory-Variables.html#index-sysconfdir-188
 populate_template = sed \
 	-e 's|@mstpdfile[@]|$(mstpdfile)|g' \
+	-e 's|@bridgestpfile[@]|$(bridgestpfile)|g' \
 	-e 's|@mstpdpidfile[@]|$(mstpdpidfile)|g' \
 	-e 's|@mstpctlfile[@]|$(mstpctlfile)|g' \
 	-e 's|@bridgestpconffile[@]|$(bridgestpconffile)|g' \
@@ -63,7 +67,7 @@ populate_template = sed \
 	-e 's|@utilsfuncfile[@]|$(utilsfuncfile)|g' \
 	-e 's|@configbridgefile[@]|$(configbridgefile)|g' \
 	-e 's|@ifqueryfile[@]|$(ifqueryfile)|g'
-bridge-stp utils/ifupdown.sh utils/mstp_config_bridge utils/mstpd.service: Makefile
+bridge-stp utils/ifupdown.sh utils/mstp_config_bridge utils/mstpd.service utils/nm-dispatcher: Makefile
 	rm -f $@ $@.tmp
 	mkdir -p $(@D)
 	srcdir=''; test -f ./$@.in || srcdir="$(srcdir)/"; \
@@ -73,6 +77,7 @@ bridge-stp utils/ifupdown.sh utils/mstp_config_bridge utils/mstpd.service: Makef
 bridge-stp: $(srcdir)/bridge-stp.in
 utils/ifupdown.sh: $(srcdir)/utils/ifupdown.sh.in
 utils/mstp_config_bridge: $(srcdir)/utils/mstp_config_bridge.in
+utils/nm-dispatcher: $(srcdir)/utils/nm-dispatcher.in
 
 sbindest=$(DESTDIR)$(sbindir)
 utilsdest=$(DESTDIR)$(utilsexecdir)
@@ -80,6 +85,7 @@ etcdest=$(DESTDIR)$(sysconfdir)
 docdest=$(DESTDIR)$(docdir)
 bashcompdest=$(DESTDIR)$(bashcompletiondir)
 systemdunitdest=$(DESTDIR)$(systemdunitdir)
+nmlibdest=$(DESTDIR)$(nmlibdir)
 
 install-exec-hook:
 	ln -sf $(sbindir)/bridge-stp $(sbindest)/mstp_restart
@@ -98,6 +104,10 @@ install-exec-hook:
 	  $(MKDIR_P) $(systemdunitdest) ; \
 	  $(INSTALL_DATA) $(top_builddir)/utils/mstpd.service $(systemdunitdest) ; \
 	fi
+	if [ -d $(nmlibdir) ]; then \
+	  $(MKDIR_P) $(nmlibdest) ; \
+	  $(INSTALL_SCRIPT) $(top_builddir)/utils/nm-dispatcher $(nmlibdest)/45-mstpd ; \
+	fi
 	$(MKDIR_P) $(docdest)
 	$(INSTALL_DATA) $(srcdir)/README.md $(docdest)/README
 	$(INSTALL_DATA) $(srcdir)/README.VLANs.md $(docdest)/README.VLANs
@@ -107,32 +117,37 @@ uninstall-hook:
 	-rm -f $(utilsdest)/mstpctl_restart_config
 	-rmdir $(utilsdest)
 	-rm -f $(bashcompdest)/mstpctl
-	-if [ -d $(sysconfdir)/network/if-pre-up.d ]; then \
+	-if [ -d $(etcdest)/network/if-pre-up.d ]; then \
 	  rm -f $(etcdest)/network/if-pre-up.d/mstpctl ; \
 	fi
-	-if [ -d $(sysconfdir)/network/if-post-down.d ]; then \
+	-if [ -d $(etcdest)/network/if-post-down.d ]; then \
 	  rm -f $(etcdest)/network/if-post-down.d/mstpctl ; \
 	fi
 	-if [ -n "$(systemdunitdir)" ]; then \
 	  rm -f $(systemdunitdest)/mstpd.service ; \
 	fi
+	-if [ -d $(nmlibdest) ]; then \
+	  rm -f $(nmlibdest)/45-mstpd ; \
+	fi
 	-rm -f $(docdest)/README
 	-rm -f $(docdest)/README.VLANs
 	-rmdir $(docdest)
 
-rpm: rpm.spec
+rpm: mstpd.spec
 	Version="$$(perl -n -e 'if(/AC_INIT[^,]+,\s+\[([^]]+)\]/) \
 	{ $$V=$$1; $$V=~s/-/_/g; print $$V; exit; }' configure.ac)" ; \
 	[ -n "$$Version" ] || exit 3 ; SrcDir="$$(pwd)" ; \
-	mkdir -p "../rpmbuild/SOURCES" ; cd "../rpmbuild/SOURCES" ; \
-	git clone "$$SrcDir" "mstpd-$$Version" ; \
-	tar -cvjf "mstpd-$$Version.tar.bz2" "mstpd-$$Version" ; \
-	rm -rf "mstpd-$$Version" ; \
-	cd .. ; mkdir -p SPECS ; cp "$$SrcDir/rpm.spec" SPECS/mstpd.spec
+	mkdir -p "../rpmbuild/SOURCES" && cd "../rpmbuild/SOURCES" && \
+	git clone "$$SrcDir" "mstpd-$$Version" && \
+	rm -rf "mstpd-$$Version/.git" && \
+	tar -cvzf "mstpd-$$Version.tar.gz" "mstpd-$$Version" && \
+	rm -rf "mstpd-$$Version" && \
+	cd .. && mkdir -p SPECS && \
+	cp "$$SrcDir/mstpd.spec" SPECS/mstpd.spec && \
 	rpmbuild --define "_topdir $$(pwd)" -ba SPECS/mstpd.spec
 
-rpm.spec: configure.ac
+mstpd.spec: configure.ac
 	Version="$$(perl -n -e 'if(/AC_INIT[^,]+,\s+\[([^]]+)\]/) \
 	{ $$V=$$1; $$V=~s/-/_/g; print $$V; exit; }' configure.ac)" ; \
 	[ -n "$$Version" ] || exit 3 ; \
-	perl -i -p -e 's/^(\s*Version:\s+).*$$/$${1}'"$$Version/" rpm.spec
+	perl -i -p -e 's/^(\s*Version:\s+).*$$/$${1}'"$$Version/" mstpd.spec

--- a/utils/ifquery
+++ b/utils/ifquery
@@ -8,6 +8,7 @@ import glob
 def parse_config(interfaces_file, interface):
     f = open(interfaces_file)
     intf = ''
+    found = False
     for line in f:
         str = line.strip().split(' ')
         len_str = len(str)
@@ -25,9 +26,13 @@ def parse_config(interfaces_file, interface):
         # Check if this is the relevant interface.
         if intf != interface:
             continue
+        found = True
         # Print configuration.
         print((str[0]+": "+" ".join(str[1:])))
     f.close()
+    if not found:
+        print("%s: unknown interface %s" % (sys.argv[0], interface))
+        sys.exit(1)
     return
 
 

--- a/utils/mstpd.service.in
+++ b/utils/mstpd.service.in
@@ -1,12 +1,13 @@
 [Unit]
 Description=MSTP daemon
-Before=network.target
+Before=network-pre.target
 
 [Service]
 Type=forking
-ExecStart=@mstpdfile@
+ExecStart=@bridgestpfile@ restart
 PIDFile=@mstpdpidfile@
-Restart=on-failure
+ExecReload=@bridgestpfile@ restart_config
+Restart=always
 PrivateTmp=yes
 ProtectHome=yes
 

--- a/utils/nm-dispatcher.in
+++ b/utils/nm-dispatcher.in
@@ -1,0 +1,19 @@
+#!/bin/sh
+# This is a NetworkManager dispatcher script for the mstpd daemon
+# to apply any configuration to bridges based on the values in
+# /etc/sysconfig/network-scripts/bridge-stp
+
+export LC_ALL=C
+
+interface=$1
+action=$2
+
+config_cmd='@configbridgefile@'
+
+if [ "$action" = "up" ] && [ -n "$interface" ]; then
+  if [ -x "$config_cmd" ] || type "$config_cmd" 2>/dev/null >/dev/null ; then
+    "$config_cmd" "$interface"
+  fi
+fi
+
+exit 0


### PR DESCRIPTION
This patch fixes rpmbuild/mock failures due to missing BuildRequires,
and references to absolute filenames during install.  In addition
it corrects the quoting of the bridge-stp file contents, and
correct several macro references.

Now mock builds correctly on Fedora/CoreOS etc

Signed-off-by: Scott Shambarger <devel@shambarger.net>