### PR TITLE
Closes #123 - Replace brctl with ip and bridge commands

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -44,6 +44,7 @@ utilsexecdir=$(libexecdir)/mstpctl-utils
 
 mstpdfile=$(sbindir)/mstpd
 mstpctlfile=$(sbindir)/mstpctl
+bridgestpfile=$(sbindir)/bridge-stp
 mstpdpidfile=$(localstatedir)/run/mstpd.pid
 bridgestpconffile=$(sysconfdir)/bridge-stp.conf
 ifupdownfile=$(utilsexecdir)/ifupdown.sh
@@ -56,6 +57,7 @@ mstpd_CFLAGS += -DMSTPD_PID_FILE='"$(mstpdpidfile)"'
 # See https://www.gnu.org/savannah-checkouts/gnu/autoconf/manual/autoconf-2.69/html_node/Installation-Directory-Variables.html#index-sysconfdir-188
 populate_template = sed \
 	-e 's|@mstpdfile[@]|$(mstpdfile)|g' \
+	-e 's|@bridgestpfile[@]|$(bridgestpfile)|g' \
 	-e 's|@mstpdpidfile[@]|$(mstpdpidfile)|g' \
 	-e 's|@mstpctlfile[@]|$(mstpctlfile)|g' \
 	-e 's|@bridgestpconffile[@]|$(bridgestpconffile)|g' \

--- a/bridge-stp.in
+++ b/bridge-stp.in
@@ -3,7 +3,8 @@
 # Configuration is in @bridgestpconffile@
 #
 # `/sbin/bridge-stp <bridge> <start|stop>` is called by the kernel when STP is
-# enabled/disabled on a bridge (via `brctl stp <bridge> <on|off>`).  The kernel
+# enabled/disabled on a bridge (via `brctl stp <bridge> <on|off>` or
+# `ip link set <bridge> type bridge stp_state <0|1>`).  The kernel
 # enables user_stp mode if that command returns 0, or enables kernel_stp mode if
 # that command returns any other value.
 #
@@ -14,7 +15,7 @@
 # (possibly in a background job after a delay; see the comments in the code
 # below).  No further configuration is performed automatically by this script at
 # that time.  Additional configuration is usually performed by
-# @ifupdownfile@ (which calls `brctl stp <bridge> on`
+# @ifupdownfile@ (which calls `ip link set <bridge> type bridge stp_state 1`
 # to trigger this script to start mstpd if necessary).
 #
 # This script is not intended to be called with the above arguments directly
@@ -80,20 +81,29 @@ MSTPD_ARGS=''
 # A space-separated list of bridges for which MSTP should be used in place of
 # the kernel's STP implementation.  If empty, MSTP will be used for all bridges.
 MSTP_BRIDGES=''
+LOGGER='logger --tag bridge-stp --stderr'
 
 # Read the config.
 if [ -e '@bridgestpconffile@' ]; then
     . '@bridgestpconffile@'
 fi
 
+errmsg () {
+  if [ -n "$LOGGER" ]; then
+    $LOGGER "$*" || { echo >&2 "$*"; LOGGER=; }
+  else
+    echo >&2 "$*"
+  fi
+}
+
 # Ensure that mstpctl and mstpd exist and are executable.
 if [ -z "$mstpctl" ] || [ ! -x "$mstpctl" ]; then
-    echo "mstpctl binary does not exist or is not executable" >&2
+    errmsg "mstpctl binary does not exist or is not executable"
     exit 2
 fi
 if [ "$MANAGE_MSTPD" = 'y' ]; then
     if [ -z "$mstpd" ] || [ ! -x "$mstpd" ]; then
-        echo "mstpd binary does not exist or is not executable" >&2
+        errmsg "mstpd binary does not exist or is not executable"
         exit 2
     fi
 fi
@@ -118,7 +128,7 @@ case "$action" in
     start)
         # Make sure the specified bridge is valid.
         if [ ! -d "$net_dir/$bridge/bridge" ]; then
-            echo "'$bridge' is not a bridge" >&2
+            errmsg "'$bridge' is not a bridge"
             exit 1
         fi
 
@@ -131,12 +141,16 @@ case "$action" in
         # Start mstpd if necessary.
         if ! pidof -c -s mstpd >/dev/null; then
             if [ "$MANAGE_MSTPD" != 'y' ]; then
-                echo 'mstpd is not running' >&2
+                errmsg 'mstpd is not running'
                 exit 3
             fi
             echo 'mstpd is not running'
             echo 'Starting mstpd ...'
             "$mstpd" $MSTPD_ARGS || exit 3
+
+            # sleep a minimal amount here so calling scripts can reach
+            # mstpd
+            sleep 0.2 2>/dev/null || sleep 1
 
             # Due to kernel locks, mstpd will not respond to mstpctl until after
             # this script exits, so `mstpctl addbridge <bridge>` must be run as
@@ -145,7 +159,8 @@ case "$action" in
             # too soon after mstpd is started, so the call must also be delayed.
             #
             # To avoid race conditions, any scripts that configure the bridge
-            # immediately after calling `brctl stp <bridge> on` should
+            # immediately after calling `brctl stp <bridge> on` or
+            # `ip link set <bridge> type bridge stp_state 1` should
             # explicitly call `mstpctl addbridge <bridge>` themselves before
             # configuring the bridge.  (It should not hurt to call
             # `mstpctl addbridge <bridge>` multiple times.)
@@ -156,7 +171,7 @@ case "$action" in
             # then dying before or when mstpctl connects to it.  To avoid that
             # possibility, we instead simply turn STP off if `mstpctl addbridge`
             # fails.
-            ( sleep 1 ; "$mstpctl" addbridge "$bridge" || brctl stp "$bridge" off ) &
+            ( sleep 1 ; "$mstpctl" addbridge "$bridge" || ip link set "$bridge" type bridge stp_state 0 ) &
             exit 0
         fi
 
@@ -173,19 +188,24 @@ case "$action" in
         fi
 
         # Exit if any other bridges are using mstpd.
-        for bridge in $(ls "$net_dir"); do
+        for xbridge in $(ls "$net_dir"); do
+            # Ignore this bridge
+            if [ "$bridge" = "$xbridge" ]; then
+                continue
+            fi
+
             # Ignore interfaces that are not bridges.
-            if [ ! -e "$net_dir/$bridge/bridge/stp_state" ]; then
+            if [ ! -e "$net_dir/$xbridge/bridge/stp_state" ]; then
                 continue
             fi
 
             # Ignore bridges that should not use MSTP.
-            if ! is_mstp_bridge "$bridge"; then
+            if ! is_mstp_bridge "$xbridge"; then
                 continue
             fi
 
             # If bridge is in user_stp mode, then it is probably using MSTP.
-            read State < "$net_dir/$bridge/bridge/stp_state"
+            read State < "$net_dir/$xbridge/bridge/stp_state"
             if [ "$State" = '2' ]; then
                 exit 0
             fi
@@ -226,7 +246,7 @@ case "$action" in
                 echo
                 echo "Skipping bridge '$bridge' that has STP disabled."
                 echo "To configure this bridge to use MSTP, run:"
-                echo "brctl stp '$bridge' on"
+                echo "ip link set '$bridge' type bridge stp_state 1"
                 continue
             fi
 
@@ -235,7 +255,8 @@ case "$action" in
                 echo
                 echo "Skipping bridge '$bridge' that is not in user_stp mode."
                 echo "To reconfigure this bridge to use MSTP, run:"
-                echo "brctl stp '$bridge' off ; brctl stp '$bridge' on"
+                echo "ip link set '$bridge' type bridge stp_state 0 ; \\"
+                echo "  ip link set '$bridge' type bridge stp_state 1"
                 continue
             fi
 

--- a/utils/ifupdown.sh.in
+++ b/utils/ifupdown.sh.in
@@ -25,9 +25,9 @@ mstpctl='@mstpctlfile@'
 if [ ! -x "$mstpctl" ]; then
   exit 0
 fi
-brctl="$(command -v brctl)"
-if [ -z "$brctl" ] || [ ! -x "$brctl" ]; then
-  echo "'brctl' binary does not exist or is not executable" >&2
+brcmd="$(command -v bridge)"
+if [ -z "$brcmd" ] || [ ! -x "$brcmd" ]; then
+  echo "'bridge' binary does not exist or is not executable" >&2
   exit 2
 fi
 ip="$(command -v ip)"
@@ -53,7 +53,7 @@ esac
 
 # Previous work (create the interface)
 if [ "$MODE" = 'start' ] && [ ! -d "/sys/class/net/$IFACE" ]; then
-  "$brctl" addbr "$IFACE" || exit 2
+  "$ip" link add "$IFACE" type bridge || exit 2
 # Previous work (stop the interface)
 elif [ "$MODE" = 'stop' ]; then
   "$ip" link set dev "$IFACE" down || exit 2
@@ -76,10 +76,10 @@ mstpctl_parse_ports $INTERFACES | while read -r i; do
       if [ -f "/proc/sys/net/ipv6/conf/$port/disable_ipv6" ]; then
         echo 1 > "/proc/sys/net/ipv6/conf/$port/disable_ipv6"
       fi
-      "$brctl" addif "$IFACE" "$port" && "$ip" link set dev "$port" up
+      "$ip" link set dev "$port" master "$IFACE" && "$ip" link set dev "$port" up
     # We detach each port of the bridge
     elif [ "$MODE" = 'stop' ] && [ -d "/sys/class/net/$IFACE/brif/$port" ]; then
-      "$ip" link set dev "$port" down && "$brctl" delif "$IFACE" "$port" && \
+      "$ip" link set dev "$port" down && "$ip" link set "$port" nomaster && \
         if [ -x /etc/network/if-post-down.d/vlan ]; then
           IFACE="$port" /etc/network/if-post-down.d/vlan
         fi
@@ -94,14 +94,15 @@ done
 if [ "$MODE" = 'start' ]; then
 
   # This triggers the kernel to run `/sbin/bridge-stp start $IFACE`
-  "$brctl" stp "$IFACE" on
+  "$ip" link set "$IFACE" type bridge stp_state 1
 
   # `mstpctl addbridge $IFACE` must be called before this script continues.
   # If mstpd is already running then /sbin/bridge-stp will call
-  # `mstpctl addbridge $IFACE` before `brctl stp $IFACE on` returns.
+  # `mstpctl addbridge $IFACE` before
+  # `ip link set <bridge> type bridge stp_state 1` returns.
   # If mstpd is not already running then /sbin/bridge-stp will start it and call
   # `mstpctl addbridge $IFACE` as a delayed background process, in which case it
-  # may not run before `brctl stp $IFACE on` returns.
+  # may not run before `ip link set <bridge> type bridge stp_state 1` returns.
   # It should not hurt to call `mstpctl addbridge $IFACE` twice, so call it
   # again to ensure that it has been called before continuing.
   # See the code and comments in /sbin/bridge-stp for more details.
@@ -116,7 +117,7 @@ if [ "$MODE" = 'start' ]; then
     age="$IF_MSTPCTL_MAXAGE"
   fi
 
-  curfwddly=$( "$mstpctl" showbridge "$IFACE" bridge-forward-delay )
+  curfwddly="$( "$mstpctl" showbridge "$IFACE" bridge-forward-delay )"
   curfwddly=$((curfwddly+curfwddly))
 
   if [ "$curfwddly" -gt "$age" ]; then
@@ -129,7 +130,7 @@ if [ "$MODE" = 'start' ]; then
       "$mstpctl" setfdelay "$IFACE" "$IF_MSTPCTL_FDELAY"
     fi
     [ "$age" -gt 0 ] && "$mstpctl" setmaxage "$IFACE" "$age"
-  fi  
+  fi
 
   if [ "$IF_MSTPCTL_MAXHOPS" ]; then
     "$mstpctl" setmaxhops "$IFACE" "$IF_MSTPCTL_MAXHOPS"
@@ -323,7 +324,7 @@ if [ "$MODE" = 'start' ]; then
       # 'disabled', except if all ports are 'disabled' and we have yet to see
       # any port transition to any other valid state.
       converged=true
-      for i in $("$brctl" showstp "$IFACE" | sed -n 's/^.*port id.*state[ \t]*\(.*\)$/\1/p'); do
+      for i in $("$brcmd" link show | grep "master $IFACE" | sed -n 's/^.*state[ ]*\([^ ]*\).*$/\1/p'); do
         if [ "$i" = 'listening' ] || [ "$i" = 'learning' ]; then
           transitioned=true
           converged=''
@@ -343,6 +344,10 @@ if [ "$MODE" = 'start' ]; then
 # Finally we destroy the interface
 elif [ "$MODE" = 'stop' ]; then
 
-  "$brctl" delbr "$IFACE"
+  brstp='@bridgestpfile@'
+  if [ -x "$brstp" ]; then
+    "$brstp" "$IFACE" stop
+  fi
+  "$ip" link del "$IFACE"
 
 fi

--- a/utils/mstp_config_bridge.in
+++ b/utils/mstp_config_bridge.in
@@ -32,16 +32,16 @@ umask 022
 PATH='/sbin:/usr/sbin:/bin:/usr/bin'
 export PATH
 
-# The mstp ifupdown.sh script will not work properly unless mstpctl, brctl, and
-# ip exist and are executable.
+# The mstp ifupdown.sh script will not work properly unless mstpctl, bridge,
+# and ip exist and are executable.
 mstpctl='@mstpctlfile@'
 if [ ! -x "$mstpctl" ]; then
   echo "'mstpctl' binary does not exist or is not executable" >&2
   exit 2
 fi
-brctl="$(command -v brctl)"
-if [ -z "$brctl" ] || [ ! -x "$brctl" ]; then
-  echo "'brctl' binary does not exist or is not executable" >&2
+brcmd="$(command -v bridge)"
+if [ -z "$brcmd" ] || [ ! -x "$brcmd" ]; then
+  echo "'bridge' binary does not exist or is not executable" >&2
   exit 2
 fi
 ip="$(command -v ip)"
@@ -82,7 +82,7 @@ eval "$(
 IFS= ; echo "$Out" | \
 while read -r Line; do
     OptName="${Line%%: *}"  # Strip everything after the first ': '
-    OptName="IF_$(echo "$OptName" | tr '[:lower:]' '[:upper:]')"  # Uppercase
+    OptName="IF_$(echo "$OptName" | tr '[:lower:]-' '[:upper:]_')"  # Uppercase
     OptVal="${Line#*: }"  # Strip everything before the first ': '
     echo "export $OptName=\"$OptVal\""
 done

--- a/utils/mstpctl.8
+++ b/utils/mstpctl.8
@@ -21,7 +21,13 @@ mstpctl \- mstpd configuration
 .BR "mstpctl [command]"
 .SH DESCRIPTION
 .B mstpctl
-is used to configure Multiple Spanning Tree daemon (mstpd). MSTPCTL is used for configuring STP parameters on bridges which have user-space STP enabled. Currently, STP is disabled by default on the bridge. To enable user-space STP, configure "brctl stp <bridge> on" while ensuring that /sbin/bridge-stp kernel helper script will return success (0) for this operation.
+is used to configure Multiple Spanning Tree daemon (mstpd). MSTPCTL is
+used for configuring STP parameters on bridges which have user-space
+STP enabled. Currently, STP is disabled by default on the bridge. To
+enable user-space STP, configure "brctl stp <bridge> on" or
+"ip link set <bridge> type bridge stp_state 1" while ensuring that
+/sbin/bridge-stp kernel helper script will return success (0) for
+this operation.
 
 .SH SPANNING TREE PROTOCOL CONFIGURATION
 
@@ -105,6 +111,7 @@ will show detailed information about the <port> of the <bridge>'s MST instance w
 
 .SH SEE ALSO
 .BR brctl(8)
+.BR ip(8)
 
 .SH AUTHOR
 The source code for mstpctl was written by Vitalii Demianets


### PR DESCRIPTION
As brctl is deprecated in many distributions (and removed in
CentOS 8 Stream), this patch replaces it with the equivalent
ip/bridge commands from iproute2 (already required).

The patch also handles a race with spawning mstpd, corrects
killing it (Fixes #122), and has bridge-stp log errors to
syslog (if possible, as stderr is not logged).

Also fixes handling of pre-up etc in interfaces parsing.

Signed-off-by: Scott Shambarger <devel@shambarger.net>