### PR TITLE
build: add option to enable installation of ifupdown scripts

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -87,17 +87,18 @@ bashcompdest=$(DESTDIR)$(bashcompletiondir)
 systemdunitdest=$(DESTDIR)$(systemdunitdir)
 nmlibdest=$(DESTDIR)$(nmlibdir)
 
+if ENABLE_INSTALL_IFUPDOWN_SCRIPTS
+IFUPDOWN_SCRIPT_INSTALL_CMDS = \
+	$(MKDIR_P) $(etcdest)/network/if-pre-up.d ; \
+	ln -sf $(utilsexecdir)/ifupdown.sh $(etcdest)/network/if-pre-up.d/mstpctl ; \
+	$(MKDIR_P) $(etcdest)/network/if-post-down.d ; \
+	ln -sf $(utilsexecdir)/ifupdown.sh $(etcdest)/network/if-post-down.d/mstpctl
+endif
+
 install-exec-hook:
 	ln -sf $(sbindir)/bridge-stp $(sbindest)/mstp_restart
 	ln -sf $(sbindir)/bridge-stp $(utilsdest)/mstpctl_restart_config
-	if [ -d $(sysconfdir)/network/if-pre-up.d ]; then \
-	  $(MKDIR_P) $(etcdest)/network/if-pre-up.d ; \
-	  ln -sf $(utilsexecdir)/ifupdown.sh $(etcdest)/network/if-pre-up.d/mstpctl ; \
-	fi
-	if [ -d $(sysconfdir)/network/if-post-down.d ]; then \
-	  $(MKDIR_P) $(etcdest)/network/if-post-down.d ; \
-	  ln -sf $(utilsexecdir)/ifupdown.sh $(etcdest)/network/if-post-down.d/mstpctl ; \
-	fi
+	$(IFUPDOWN_SCRIPT_INSTALL_CMDS)
 	$(MKDIR_P) $(bashcompdest)
 	$(INSTALL_DATA) $(srcdir)/utils/bash_completion $(bashcompdest)/mstpctl
 	if [ -n "$(systemdunitdir)" ]; then \

--- a/configure.ac
+++ b/configure.ac
@@ -45,10 +45,9 @@ PKG_PROG_PKG_CONFIG
 
 # Optional building of examples
 AC_ARG_ENABLE([devel],
-	[AC_HELP_STRING([--enable-devel], [build devel mode])],
-	[enable_devel=yes], [])
+	[AC_HELP_STRING([--enable-devel], [build devel mode])])
 
-AM_CONDITIONAL([ENABLE_DEVEL], [test "$enable_devel" = yes])
+AM_CONDITIONAL([ENABLE_DEVEL], [test "x$enable_devel" = "xyes"])
 
 AC_ARG_WITH([bashcompletiondir],
      [AS_HELP_STRING([--with-bashcompletiondir=DIR], [Directory for bash completion files.

--- a/configure.ac
+++ b/configure.ac
@@ -49,6 +49,11 @@ AC_ARG_ENABLE([devel],
 
 AM_CONDITIONAL([ENABLE_DEVEL], [test "x$enable_devel" = "xyes"])
 
+AC_ARG_ENABLE([install-ifupdown-scripts],
+	[AC_HELP_STRING([--enable-install-ifupdown-scripts], [enable installation of ifupdown scripts])])
+
+AM_CONDITIONAL([ENABLE_INSTALL_IFUPDOWN_SCRIPTS], [test "x$enable_install_ifupdown_scripts" = "xyes"])
+
 AC_ARG_WITH([bashcompletiondir],
      [AS_HELP_STRING([--with-bashcompletiondir=DIR], [Directory for bash completion files.
      [default=${sysconfdir}/bash_completion.d]])],,


### PR DESCRIPTION
The current setup with the ifupdown scripts, is that they get installed if
the system that builds mstpd is a Debian system.

When building for Debian on another host, or cross-compiling via Yocto or
some other build-system, this can be problematic as the host-system can be
different, so we cannot rely on the fact that the ifupdown package is
present on the target system.

So, the option is to enable the installation of MSTPD's ifupdown scripts
via a configure flag.
Initially this was discussed that this should be a
`--disable-ifupdown-scripts`, but this seems problematic as the only place
where this is needed is for Debian/Ubuntu systems.

Also, ifupdown seems to be going away from Debian as default, so maybe the
a --enable-install-ifupdown-scripts options is better.

Fixes: #126

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>