### PR TITLE
bridge-stp.in: use short-hand arguments for logger command

### DIFF
--- a/bridge-stp.in
+++ b/bridge-stp.in
@@ -81,7 +81,7 @@ MSTPD_ARGS=''
 # A space-separated list of bridges for which MSTP should be used in place of
 # the kernel's STP implementation.  If empty, MSTP will be used for all bridges.
 MSTP_BRIDGES=''
-LOGGER='logger --tag bridge-stp --stderr'
+LOGGER='logger -t bridge-stp -s'
 
 # Read the config.
 if [ -e '@bridgestpconffile@' ]; then


### PR DESCRIPTION
Reported via: https://github.com/mstpd/mstpd/issues/134

```
bridge-stp script calls logger with the full options --tag and --stderr
BusyBox only supports the shorthand of the options -t and -s respectively.
The shorthands should also work on non-busybox systems.

https://elixir.bootlin.com/busybox/1.35.0/source/sysklogd/logger.c
https://man7.org/linux/man-pages/man1/logger.1.html
```

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>