### PR TITLE
mstpctl-utils-functions.sh: fix shellcheck warnings

### DIFF
--- a/utils/mstpctl-utils-functions.sh
+++ b/utils/mstpctl-utils-functions.sh
@@ -2,7 +2,7 @@
 
 mstpctl_parse_ports()
 {
-  while [ x"${1+set}" = xset ]
+  while [ "${1+set}" = set ]
   do
     # For compatibility: the 'all' option.
     case $1 in
@@ -50,6 +50,6 @@ EOAI
 	;;
     esac
 
-    echo $i
+    echo "$i"
   done
 }


### PR DESCRIPTION
Fix the following shellcheck warnings:

```
In utils/mstpctl-utils-functions.sh line 5:
  while [ x"${1+set}" = xset ]
          ^---------^ SC2268 (style): Avoid x-prefix in comparisons as it no longer serves a purpose.

Did you mean:
  while [ "${1+set}" = set ]

In utils/mstpctl-utils-functions.sh line 53:
    echo $i
         ^-- SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    echo "$i"
```