### PR TITLE
do not leak stack memory via struct holes

### DIFF
--- a/ctl_functions.h
+++ b/ctl_functions.h
@@ -474,6 +474,7 @@ CTL_DECLARE(del_bridges);
             return -1;                                       \
         }                                                    \
         memcpy(in, inbuf, lin);                              \
+        memset(out, 0, lout);                                \
         int r = CTL_ ## name name ## _CALL;                  \
         if(r)                                                \
             return r;                                        \


### PR DESCRIPTION
The various structs used by mstpd may have holes in them due to alignment constraints of following struct members.

E.g. with the layout

```
struct foo {
   int field1;
   bool field2;
   int field3;
};
```

field3 needs a 4 byte alignment, but bool is only 1 byte, so there are 3 unused bytes between field2 and field3.

The various MSTP_IN_* functions set all members of the passed struct, but do not touch the holes. This is usually fine within the server, but when passing on data to clients via the socket, we may leak stack memory via these holes:

```
    case CMD_CODE_ ## name : do                              \
    {                                                        \
        struct name ## _IN in0, *in = &in0;                  \
        struct name ## _OUT out0, *out = &out0;              \
        /*  uninitialized stack -^ */                        \
        if(sizeof(*in) != lin || sizeof(*out) != lout)       \
        {                                                    \
            LOG("Bad sizes lin %d != %zd or lout %d != %zd", \
                lin, sizeof(*in), lout, sizeof(*out));       \
            return -1;                                       \
        }                                                    \
        memcpy(in, inbuf, lin);                              \
        int r = CTL_ ## name name ## _CALL;                  \
        /*only initializes the members -^ */                 \
        if(r)                                                \
            return r;                                        \
        if(outbuf)                                           \
            memcpy(outbuf, out, lout);                       \
            /* copies uninitialized stack memory */          \
        return r;                                            \
    }while(0)
```

Fix this by initializing the on-stack out object first.

Found via valgrind, e.g.:

```
==2786== Syscall param sendmsg(msg.msg_iov[1]) points to uninitialised byte(s)
==2786==    at 0x4967397: sendmsg (sendmsg.c:28)
==2786==    by 0x11A11D: ctl_rcv_handler (ctl_socket_server.c:255)
==2786==    by 0x10AE76: epoll_main_loop (epoll_loop.c:151)
==2786==    by 0x10A5FC: main (main.c:188)
==2786==  Address 0x125231 is 49 bytes inside data symbol "msg_outbuf"
==2786==  Uninitialised value was created by a stack allocation
==2786==    at 0x11923A: handle_message.constprop.0 (ctl_socket_server.c:59)
==2786==
```

Byte 49 in this example is the hole between
CIST_BridgeStatus::last_topology_change_port (bytes 33 - 48) and CIST_BridgeStatus::designated_root, which needs 8-byte alignment, so is at bytes 56 - 63, leaving a 7 byte hole between them.