### PR TITLE
ctl_socket_server: require root for changing configuration

### DIFF
--- a/ctl_socket_server.c
+++ b/ctl_socket_server.c
@@ -34,7 +34,7 @@
 static int server_socket(void)
 {
     struct sockaddr_un sa;
-    int s;
+    int s, creds;
 
     TST(strlen(MSTP_SERVER_SOCK_NAME) < sizeof(sa.sun_path), -1);
 
@@ -45,6 +45,14 @@ static int server_socket(void)
     }
 
     set_socket_address(&sa, MSTP_SERVER_SOCK_NAME);
+
+    creds = 1;
+    if(0 != setsockopt(s, SOL_SOCKET, SO_PASSCRED, &creds, sizeof(creds)))
+    {
+        ERROR("Couldn't enable SO_PASSCRED: %m");
+        close(s);
+        return -1;
+    }
 
     if(0 != bind(s, (struct sockaddr *)&sa, sizeof(sa)))
     {
@@ -199,6 +207,25 @@ void _ctl_err_log(char *fmt, ...)
 #define MSG_BUF_LEN 10000
 static unsigned char msg_inbuf[MSG_BUF_LEN];
 static unsigned char msg_outbuf[MSG_BUF_LEN];
+static unsigned char msg_ctlbuf[CMSG_SPACE(sizeof(struct ucred))];
+
+static bool ctl_access_ok(const struct ucred *creds, int cmd)
+{
+    switch(cmd)
+    {
+        case CMD_CODE_get_cist_bridge_status:
+        case CMD_CODE_get_msti_bridge_status:
+        case CMD_CODE_get_cist_port_status:
+        case CMD_CODE_get_msti_port_status:
+        case CMD_CODE_get_mstilist:
+        case CMD_CODE_get_mstconfid:
+        case CMD_CODE_get_vids2fids:
+        case CMD_CODE_get_fids2mstids:
+            return true;
+        default:
+            return creds->uid == 0;
+    }
+}
 
 static void ctl_rcv_handler(uint32_t events, struct epoll_event_handler *p)
 {
@@ -206,14 +233,16 @@ static void ctl_rcv_handler(uint32_t events, struct epoll_event_handler *p)
     struct msghdr msg;
     struct sockaddr_un sa;
     struct iovec iov[3];
+    struct cmsghdr *cmsg;
+    struct ucred *creds;
     int l;
 
     msg.msg_name = &sa;
     msg.msg_namelen = sizeof(sa);
     msg.msg_iov = iov;
     msg.msg_iovlen = 3;
-    msg.msg_control = NULL;
-    msg.msg_controllen = 0;
+    msg.msg_control = msg_ctlbuf;
+    msg.msg_controllen = sizeof(msg_ctlbuf);
     iov[0].iov_base = &mhdr;
     iov[0].iov_len = sizeof(mhdr);
     iov[1].iov_base = msg_inbuf;
@@ -232,15 +261,32 @@ static void ctl_rcv_handler(uint32_t events, struct epoll_event_handler *p)
         return;
     }
 
+    cmsg = CMSG_FIRSTHDR(&msg);
+
+    if(!cmsg || (cmsg->cmsg_level != SOL_SOCKET)
+       || (cmsg->cmsg_type != SCM_CREDENTIALS)
+       || (cmsg->cmsg_len != CMSG_LEN(sizeof(struct ucred)))
+      )
+    {
+        ERROR("CTL: No creds or unexpected control message. Ignoring");
+        return;
+    }
+
+    creds = (struct ucred *)CMSG_DATA(cmsg);
+
     msg_log_offset = 0;
     ctl_in_handler = 1;
+    if(ctl_access_ok(creds, mhdr.cmd)) {
+        if(!(mhdr.cmd & RESPONSE_FIRST_HANDLE_LATER))
+            mhdr.res = handle_message(mhdr.cmd, msg_inbuf, mhdr.lin,
+                                      msg_outbuf, mhdr.lout);
+        else
+            mhdr.res = 0;
 
-    if(!(mhdr.cmd & RESPONSE_FIRST_HANDLE_LATER))
-        mhdr.res = handle_message(mhdr.cmd, msg_inbuf, mhdr.lin,
-                                  msg_outbuf, mhdr.lout);
-    else
-        mhdr.res = 0;
-
+    } else {
+        ERROR("Operation not permitted");
+        mhdr.res = -1;
+    }
     ctl_in_handler = 0;
     if(0 > mhdr.res)
         memset(msg_outbuf, 0, mhdr.lout);
@@ -261,7 +307,7 @@ static void ctl_rcv_handler(uint32_t events, struct epoll_event_handler *p)
              l, sizeof(mhdr) + mhdr.lout + mhdr.llog);
     }
 
-    if(mhdr.cmd & RESPONSE_FIRST_HANDLE_LATER)
+    if(mhdr.res == 0 && mhdr.cmd & RESPONSE_FIRST_HANDLE_LATER)
         handle_message(mhdr.cmd, msg_inbuf, mhdr.lin, msg_outbuf, mhdr.lout);
 }
 


### PR DESCRIPTION
Currently the server unix socket is world-writable, which means that everyone can change the mstpd configuration. This is obviously sub-optimal, so enable SO_PASSCRED and check that the caller is root before changing any configuration.

Reading configuration and state is still allowed for everyone, to still allow any monitoring software to continue monitoring the system even without root privileges.