### PR TITLE
bridge detection: check for proposing in any tree

### DIFF
--- a/mstp.c
+++ b/mstp.c
@@ -3096,7 +3096,8 @@ static void BDSM_begin(port_t *prt/*, bool begin*/)
 
 static bool BDSM_run(port_t *prt, bool dry_run)
 {
-    per_tree_port_t *cist;
+    per_tree_port_t *ptp;
+    bool proposing = false;
 
     switch(prt->BDSM_state)
     {
@@ -3111,16 +3112,18 @@ static bool BDSM_run(port_t *prt, bool dry_run)
             }
             return false;
         case BDSM_NOT_EDGE:
-             cist = GET_CIST_PTP_FROM_PORT(prt);
-            /* NOTE: 802.1Q-2005(-2011) is not clear, which of the per-tree
-             *  "proposing" flags to use here, or one should combine
-             *  them all for all trees?
-             * So, I decide that it will be the "proposing" flag
-             *  from CIST tree - it seems like a good bet.
-             */
+            FOREACH_PTP_IN_PORT(ptp, prt)
+            {
+                if(ptp->proposing)
+                {
+                    proposing = true;
+                    break;
+                }
+            }
+
             if((!prt->portEnabled && prt->AdminEdgePort)
                || ((0 == prt->edgeDelayWhile) && prt->AutoEdge && prt->sendRSTP
-                   && cist->proposing)
+                   && proposing)
               )
             {
                 if(dry_run) /* state change */


### PR DESCRIPTION
IEEE 802.1Q-2022 figure 13-13 has an arrow with proposing from PORT ROLE TRANSITIONS to BRIDGE DETECTION, implying that this is any tree, not just CIST.

Mick Seaman also agrees with this in [1] (p. 6):

> The Bridge Detection Machine (BDM, 13.33) is
> responsible for setting isolate. It is a per port (not per
> tree) state machine but uses the per tree variable
> proposing without further clarification. For RSTP this
> is fine, as there is only one tree to consider, for MSTP
> isolate needs to be set if proposing is set for the CIST or
> any MSTI. This needs to be clarified in the standard.

The variable proposing is used in both NOT_EDGE to EDGE and to ISOLATED transitions, so it applies also without isolation support.

[1] https://www.ieee802.org/1/files/public/docs2024/dy-seaman-fragile-bridges-revisited-0724-v2.pdf