### PR TITLE
mstp: increase maxHops limit to 100

### DIFF
--- a/mstp.c
+++ b/mstp.c
@@ -833,9 +833,9 @@ int MSTP_IN_set_cist_bridge_config(bridge_t *br, CIST_BridgeConfig *cfg)
 
     if(cfg->set_max_hops)
     {
-        if((6 > cfg->max_hops) || (40 < cfg->max_hops))
+        if((6 > cfg->max_hops) || (100 < cfg->max_hops))
         {
-            ERROR_BRNAME(br, "Bridge Max Hops must be between 6 and 40");
+            ERROR_BRNAME(br, "Bridge Max Hops must be between 6 and 100");
             r = -1;
         }
     }


### PR DESCRIPTION
IEEE 802.1Qdy-2025 ("Amendment 40: YANG for the Multiple Spanning Tree Protocol") updates the Max Hops range from 6 - 40 to 6 - 100.

Update our checks accordingly.