### PR TITLE
packet: set socket priority to TC_PRIO_CONTROL

### DIFF
--- a/packet.c
+++ b/packet.c
@@ -32,6 +32,7 @@
 #include <netinet/in.h>
 #include <linux/if_packet.h>
 #include <linux/filter.h>
+#include <linux/pkt_sched.h>
 #include <asm/byteorder.h>
 
 #include "epoll_loop.h"
@@ -176,6 +177,11 @@ int packet_sock_init(void)
         ERROR("fcntl set nonblock failed: %m");
     else
     {
+        int prio = TC_PRIO_CONTROL;
+
+        if(setsockopt(s, SOL_SOCKET, SO_PRIORITY, &prio, sizeof(prio)) < 0)
+            ERROR("setsockopt priority failed, BPDU delivery may be unreliable: %m");
+
         packet_event.fd = s;
         packet_event.handler = packet_rcv;
 


### PR DESCRIPTION
Default socket priority is best effort, which may compete with other streams when the interfaces are busy transmitting packets, or even fail to enqueue if the packet queue is full.

Send BPDUs instead with the highest priority TC_PRIO_CONTROL, to ensure they get sent out as soon as possible, and go into a different queue, assuming the packet scheduler selected has multiple queues.

This should increase likelihood of sending out BPDUs and sending them timely.