### PR TITLE
README.md: fix MSTI limits and clarify Linux bridging support

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,13 +59,13 @@ in-kernel stp!).
 MSTP standard (802.1Q-2005) requires from the bridge to be heavily
 interconnected with the VLANs infrastructure, namely:
 
-  - Support several (2 .. 65) independent FIDs (Forwarding Information
+  - Support several (2 .. 4094) independent FIDs (Forwarding Information
   Databases). Each VLAN belongs to the one of FIDs, and learning of the
   MAC addresses is done independently in the each FID (independent
   learning as opposed to shared learning in the current Linux bridges);
 
-  - Support several (2 .. 65) Multiple Spanning Tree Instances. Each FID
-  belongs to the one of MSTIs;
+  - Support several (2 .. 64) Multiple Spanning Tree Instances in
+    addition to the CIST. Each FID belongs to the one of MSTIs or CIST;
 
   - Support per-MSTI port states (Discarding / Learning / Forwarding) so
   that each bridge port can have different states for different MSTIs.

--- a/README.md
+++ b/README.md
@@ -70,13 +70,25 @@ interconnected with the VLANs infrastructure, namely:
   - Support per-MSTI port states (Discarding / Learning / Forwarding) so
   that each bridge port can have different states for different MSTIs.
 
-This is a big flaw in Linux. Actually, in Linux bridge code is totally
-independent from VLAN code and given wide deployment of the 802.1Q-2005
-compatible bridges this is wrong approach. Bridge and VLAN code should
-be merged together.
+Linux bridging supports either IVL or SVL, but does not support dynamic
+allocation of VIDs to FIDs.
 
-Anyway, this is not true for now, so MSTP daemon is not as useful for
-the bare Linux box (except for the (R)STP case - as stated above it
+This is controlled via the VLAN filtering attribute:
+
+  - When VLAN filtering is enabled, the bridge supports 4094 VLANs with
+    IVL, and requires configuration of all VLANs permitted;
+  - When VLAN filtering is disabled, the bridge is not VLAN aware and only
+    learns via the MAC address (into a separate "untagged" FID), so it does
+    SVL.
+
+Additionally Linux bridging gained support for MSTIs in version 5.18:
+
+  - VLANs configured on the bridge can be assigned to MSTIs;
+  - Once a VLANs is assigned to a MSTI, the port states of ports that are
+    members of that VLAN can be configured
+
+MSTPD currently does not handle this, so MSTP daemon is not as useful
+for the bare Linux box (except for the (R)STP case - as stated above it
 works with the kernel bridge well enough in this case). But there are
 plenty embedded cases where bridging functions are implemented by
 specialized hardware with support of custom drivers. For such cases MSTP


### PR DESCRIPTION
Fix the to be supported limits to

* 4094 (number of VLANs) for FIDs
* 64 for MSTI and explicitly count CIST separately

to match 802.1Q(-2022).

Also clarify the state of VLAN and MSTI support in Linux, and its support in MSTPD.