### PR TITLE
Fix race condition on add_bridge command

### DIFF
--- a/bridge_track.c
+++ b/bridge_track.c
@@ -130,6 +130,7 @@ static port_t * find_if(bridge_t * br, int if_index)
 
 static inline void delete_if(port_t *prt)
 {
+    INFO("Del iface %s", prt->sysdeps.name);
     MSTP_IN_delete_port(prt);
     free(prt);
 }
@@ -161,7 +162,10 @@ void bridge_one_second(void)
 {
     bridge_t *br;
     list_for_each_entry(br, &bridges, list)
-        MSTP_IN_one_second(br);
+    {
+        if(br->stp_enabled)
+            MSTP_IN_one_second(br);
+    }
 }
 
 /* New MAC address is stored in addr, which also holds the old value on entry.
@@ -203,7 +207,7 @@ static void set_br_up(bridge_t * br, bool up)
         MSTP_IN_set_bridge_address(br, br->sysdeps.macaddr);
     }
 
-    if(changed)
+    if(changed && br->stp_enabled)
         MSTP_IN_set_bridge_enable(br, br->sysdeps.up);
 }
 
@@ -258,7 +262,7 @@ static void set_if_up(port_t *prt, bool up)
             changed = true;
         }
     }
-    if(changed)
+    if(changed && prt->bridge->stp_enabled)
         MSTP_IN_set_port_enable(prt, prt->sysdeps.up, prt->sysdeps.speed,
                                 prt->sysdeps.duplex);
 }
@@ -277,7 +281,15 @@ int bridge_notify(int br_index, int if_index, bool newlink, unsigned flags)
     if((br_index >= 0) && (br_index != if_index))
     {
         if(!(br = find_br(br_index)))
-            return -2; /* bridge not in list */
+        {
+            /* Auto-create bridge in monitoring mode */
+            if(!(br = create_br(br_index)))
+            {
+                ERROR("Couldn't create data for bridge interface %d", br_index);
+                return -2;
+            }
+            INFO("Auto-monitor bridge %s", br->sysdeps.name);
+        }
         int br_flags = get_flags(br->sysdeps.name);
         if(br_flags >= 0)
             set_br_up(br, !!(br_flags & IFF_UP));
@@ -339,7 +351,15 @@ int bridge_notify(int br_index, int if_index, bool newlink, unsigned flags)
             if(br_index == if_index)
             {
                 if(!(br = find_br(br_index)))
-                    return -2; /* bridge not in list */
+                {
+                    /* Auto-create bridge in monitoring mode */
+                    if(!(br = create_br(br_index)))
+                    {
+                        ERROR("Couldn't create data for bridge interface %d", br_index);
+                        return -2;
+                    }
+                    INFO("Auto-monitor bridge %s", br->sysdeps.name);
+                }
                 set_br_up(br, up);
             }
         }
@@ -835,14 +855,11 @@ int CTL_set_fids2mstids(int br_index, __u16 *fids2mstids)
     return MSTP_IN_set_all_fids2mstids(br, fids2mstids) ? 0 : -1;
 }
 
-int CTL_add_bridges(int *br_array, int* *ifaces_lists)
+int CTL_add_bridges(int *br_array)
 {
-    int i, j, ifcount, brcount = br_array[0];
-    bridge_t *br, *other_br;
-    port_t *prt, *nxt;
-    int br_flags, if_flags;
-    int *if_array;
-    bool found;
+    int i, brcount = br_array[0];
+    bridge_t *br;
+    port_t *prt;
 
     for(i = 1; i <= brcount; ++i)
     {
@@ -854,54 +871,23 @@ int CTL_add_bridges(int *br_array, int* *ifaces_lists)
                       br_array[i]);
                 return -1;
             }
-            if(0 <= (br_flags = get_flags(br->sysdeps.name)))
-                set_br_up(br, !!(br_flags & IFF_UP));
         }
-        if_array = ifaces_lists[i - 1];
-        ifcount = if_array[0];
-        /* delete all interfaces which are not in list */
-        list_for_each_entry_safe(prt, nxt, &br->ports, br_list)
+
+        if(br->stp_enabled)
+            continue; /* already managed */
+
+        br->stp_enabled = true;
+        INFO("Enable STP on bridge %s", br->sysdeps.name);
+
+        /* Enable the bridge directly - sysdeps.up may already be set
+         * from monitoring, so set_br_up would not detect a change */
+        MSTP_IN_set_bridge_enable(br, br->sysdeps.up);
+
+        /* Enable all existing ports */
+        list_for_each_entry(prt, &br->ports, br_list)
         {
-            found = false;
-            for(j = 1; j <= ifcount; ++j)
-            {
-                if(prt->sysdeps.if_index == if_array[j])
-                {
-                    found = true;
-                    break;
-                }
-            }
-            if(!found)
-                delete_if(prt);
-        }
-        /* add all new interfaces from the list */
-        for(j = 1; j <= ifcount; ++j)
-        {
-            if(NULL != find_if(br, if_array[j]))
-                continue;
-            /* Check if this interface is slave of another bridge */
-            list_for_each_entry(other_br, &bridges, list)
-            {
-                if(other_br != br)
-                    if(delete_if_byindex(other_br, if_array[j]))
-                    {
-                        INFO("Device %d has come to bridge %s. "
-                             "Missed notify for deletion from bridge %s",
-                             if_array[j], br->sysdeps.name,
-                             other_br->sysdeps.name);
-                        break;
-                    }
-            }
-            if(NULL == (prt = create_if(br, if_array[j])))
-            {
-                INFO("Couldn't create data for interface %d (master %s)",
-                     if_array[j], br->sysdeps.name);
-                continue;
-            }
-            if(0 <= (if_flags = get_flags(prt->sysdeps.name)))
-                set_if_up(prt, (IFF_UP | IFF_RUNNING) ==
-                               (if_flags & (IFF_UP | IFF_RUNNING))
-                         );
+            MSTP_IN_set_port_enable(prt, prt->sysdeps.up, prt->sysdeps.speed,
+                                    prt->sysdeps.duplex);
         }
     }
 
@@ -911,9 +897,24 @@ int CTL_add_bridges(int *br_array, int* *ifaces_lists)
 int CTL_del_bridges(int *br_array)
 {
     int i, brcount = br_array[0];
+    bridge_t *br;
+    port_t *prt;
 
     for(i = 1; i <= brcount; ++i)
-        delete_br_byindex(br_array[i]);
+    {
+        if(!(br = find_br(br_array[i])))
+            continue;
+        if(br->stp_enabled)
+        {
+            INFO("Disable STP on bridge %s", br->sysdeps.name);
+            /* Disable all ports */
+            list_for_each_entry(prt, &br->ports, br_list)
+                MSTP_IN_set_port_enable(prt, false, 0, 0);
+            /* Disable the bridge */
+            MSTP_IN_set_bridge_enable(br, false);
+            br->stp_enabled = false;
+        }
+    }
 
     return 0;
 }

--- a/ctl_functions.h
+++ b/ctl_functions.h
@@ -453,7 +453,7 @@ CTL_DECLARE(set_fids2mstids);
 
 /* add bridges */
 #define CMD_CODE_add_bridges    (122 | RESPONSE_FIRST_HANDLE_LATER)
-#define add_bridges_ARGS (int *br_array, int* *ifaces_lists)
+#define add_bridges_ARGS (int *br_array)
 CTL_DECLARE(add_bridges);
 
 /* delete bridges */

--- a/ctl_main.c
+++ b/ctl_main.c
@@ -173,6 +173,8 @@ typedef enum {
     PARAM_SENDRSTP,
     PARAM_RCVDTCACK,
     PARAM_RCVDTCN,
+    /* Not standard */
+    PARAM_STPENABLED,
 } param_id_t;
 
 typedef struct {
@@ -181,6 +183,7 @@ typedef struct {
 } cmd_param_t;
 
 static const cmd_param_t cist_bridge_params[] = {
+    { PARAM_STPENABLED,     "stp enabled" },
     { PARAM_ENABLED,      "enabled" },
     { PARAM_BRID,         "bridge-id" },
     { PARAM_DSGNROOT,     "designated-root" },
@@ -213,6 +216,7 @@ static int do_showbridge_fmt_plain(const CIST_BridgeStatus *s,
     {
         case PARAM_NULL:
             printf("%s CIST info\n", br_name);
+            printf("  stp enabled     %s\n", BOOL_STR(s->stp_enabled));
             printf("  enabled         %s\n", BOOL_STR(s->enabled));
             printf("  bridge id       "BR_ID_FMT"\n",
                    BR_ID_ARGS(s->bridge_id));
@@ -247,6 +251,9 @@ static int do_showbridge_fmt_plain(const CIST_BridgeStatus *s,
                    s->topology_change_port);
             printf("  last topology change port  %s\n",
                    s->last_topology_change_port);
+            break;
+        case PARAM_STPENABLED:
+            printf("%s\n", BOOL_STR(s->stp_enabled));
             break;
         case PARAM_ENABLED:
             printf("%s\n", BOOL_STR(s->enabled));
@@ -327,6 +334,7 @@ static int do_showbridge_fmt_json(const CIST_BridgeStatus *s,
         case PARAM_NULL:
             printf("{");
             printf("\"bridge\":\"%s\",", br_name);
+            printf("\"stp-enabled\":\"%s\",", BOOL_STR(s->stp_enabled));
             printf("\"enabled\":\"%s\",", BOOL_STR(s->enabled));
             printf("\"bridge-id\":\""BR_ID_FMT"\",",
                    BR_ID_ARGS(s->bridge_id));
@@ -368,6 +376,7 @@ static int do_showbridge_fmt_json(const CIST_BridgeStatus *s,
                    s->last_topology_change_port);
             printf("}");
             break;
+        case PARAM_STPENABLED:
         case PARAM_ENABLED:
         case PARAM_BRID:
         case PARAM_DSGNROOT:
@@ -1381,64 +1390,21 @@ static int cmd_showtreeport(int argc, char *const *argv)
 
 static int cmd_addbridge(int argc, char *const *argv)
 {
-    int i, j, res, ifcount, brcount = argc - 1;
+    int i, res, brcount = argc - 1;
     int *br_array;
-    int* *ifaces_lists;
 
     if(NULL == (br_array = malloc((brcount + 1) * sizeof(int))))
     {
-out_of_memory_exit:
         fprintf(stderr, "out of memory, brcount = %d\n", brcount);
         return -1;
-    }
-    if(NULL == (ifaces_lists = malloc(brcount * sizeof(int*))))
-    {
-        free(br_array);
-        goto out_of_memory_exit;
     }
 
     br_array[0] = brcount;
     for(i = 1; i <= brcount; ++i)
-    {
-        struct dirent **namelist;
-
         br_array[i] = get_index(argv[i], "bridge");
 
-        if(0 > (ifcount = get_port_list(argv[i], &namelist)))
-        {
-ifaces_error_exit:
-            for(i -= 2; i >= 0; --i)
-                free(ifaces_lists[i]);
-            free(ifaces_lists);
-            free(br_array);
-            return ifcount;
-        }
+    res = CTL_add_bridges(br_array);
 
-        if(NULL == (ifaces_lists[i - 1] = malloc((ifcount + 1) * sizeof(int))))
-        {
-            fprintf(stderr, "out of memory, bridge %s, ifcount = %d\n",
-                    argv[i], ifcount);
-            for(j = 0; j < ifcount; ++j)
-                free(namelist[j]);
-            free(namelist);
-            ifcount = -1;
-            goto ifaces_error_exit;
-        }
-
-        ifaces_lists[i - 1][0] = ifcount;
-        for(j = 1; j <= ifcount; ++j)
-        {
-            ifaces_lists[i - 1][j] = get_index(namelist[j - 1]->d_name, "port");
-            free(namelist[j - 1]);
-        }
-        free(namelist);
-    }
-
-    res = CTL_add_bridges(br_array, ifaces_lists);
-
-    for(i = 0; i < brcount; ++i)
-        free(ifaces_lists[i]);
-    free(ifaces_lists);
     free(br_array);
     return res;
 }
@@ -2624,31 +2590,9 @@ CTL_DECLARE(add_bridges)
 {
     int res = 0;
     LogString log = { .buf = "" };
-    int i, chunk_count, brcount, serialized_data_count;
-    int *serialized_data, *ptr;
-
-    chunk_count = serialized_data_count = (brcount = br_array[0]) + 1;
-    for(i = 0; i < brcount; ++i)
-        serialized_data_count += ifaces_lists[i][0] + 1;
-    if(NULL == (serialized_data = malloc(serialized_data_count * sizeof(int))))
-    {
-        LOG("out of memory, serialized_data_count = %d",
-            serialized_data_count);
-        return -1;
-    }
-    memcpy(serialized_data, br_array, chunk_count * sizeof(int));
-    ptr = serialized_data + chunk_count;
-    for(i = 0; i < brcount; ++i)
-    {
-        chunk_count = ifaces_lists[i][0] + 1;
-        memcpy(ptr, ifaces_lists[i], chunk_count * sizeof(int));
-        ptr += chunk_count;
-    }
-
-    int r = send_ctl_message(CMD_CODE_add_bridges, serialized_data,
-                             serialized_data_count * sizeof(int),
+    int r = send_ctl_message(CMD_CODE_add_bridges, br_array,
+                             (br_array[0] + 1) * sizeof(int),
                              NULL, 0, &log, &res);
-    free(serialized_data);
     if(r || res)
         LOG("Got return code %d, %d\n%s", r, res, log.buf);
     if(r)

--- a/ctl_socket_server.c
+++ b/ctl_socket_server.c
@@ -104,47 +104,19 @@ static int handle_message(int cmd, void *inbuf, int lin,
                 return -1;
             }
             int *br_array = inbuf;
-            int i, serialized_data_count, chunk_count, brcount = br_array[0];
-            int *ptr = br_array + (serialized_data_count = (brcount + 1));
-            if(lin < ((serialized_data_count + 1) * sizeof(int)))
+            int brcount = br_array[0];
+            /*
+             * Accept more data for compatibility with old API
+             * where interfaces belonging to the bridge were provided
+             * by clients implementing their own mstpctl application.
+             */
+            if(lin < ((brcount + 1) * sizeof(int)))
             {
-bad_lin1:       LOG("Bad sizes: lin %d < %d", lin,
-                    (serialized_data_count + 1) * sizeof(int));
+                LOG("Bad sizes: lin %d < %d", lin,
+                    (brcount + 1) * sizeof(int));
                 return -1;
             }
-            for(i = 0; i < brcount; ++i)
-            {
-                serialized_data_count += (chunk_count = *ptr + 1);
-                if(i < (brcount - 1))
-                {
-                    if(lin < ((serialized_data_count + 1) * sizeof(int)))
-                        goto bad_lin1;
-                    ptr += chunk_count;
-                }
-                else
-                {
-                    if(lin != (serialized_data_count * sizeof(int)))
-                    {
-                        LOG("Bad sizes: lin %d != %d", lin,
-                            serialized_data_count * sizeof(int));
-                        return -1;
-                    }
-                }
-            }
-            int* *ifaces_lists = malloc(brcount * sizeof(int*));
-            if(NULL == ifaces_lists)
-            {
-                LOG("out of memory, brcount = %d\n", brcount);
-                return -1;
-            }
-            ptr = br_array + (brcount + 1);
-            for(i = 0; i < brcount; ++i)
-            {
-                ifaces_lists[i] = ptr;
-                ptr += ifaces_lists[i][0] + 1;
-            }
-            int r = CTL_add_bridges(br_array, ifaces_lists);
-            free(ifaces_lists);
+            int r = CTL_add_bridges(br_array);
             if(r)
                 return r;
             return r;

--- a/mstp.c
+++ b/mstp.c
@@ -738,6 +738,7 @@ void MSTP_IN_get_cist_bridge_status(bridge_t *br, CIST_BridgeStatus *status)
     assign(status->tx_hold_count, br->Transmit_Hold_Count);
     status->protocol_version = br->ForceProtocolVersion;
     status->enabled = br->bridgeEnabled;
+    status->stp_enabled = br->stp_enabled;
     assign(status->bridge_hello_time, br->Hello_Time);
     assign(status->Ageing_Time, br->Ageing_Time);
 }

--- a/mstp.h
+++ b/mstp.h
@@ -402,6 +402,7 @@ typedef struct
 
     /* not in standard */
     unsigned int uptime;
+    bool stp_enabled;
 
     sysdep_br_data_t sysdeps;
 } bridge_t;
@@ -611,6 +612,7 @@ typedef struct
     bridge_identifier_t regional_root;
     unsigned int internal_path_cost;
     bool enabled; /* not in standard */
+    bool stp_enabled; /* not in standard */
     unsigned int Ageing_Time;
     __u8 max_hops;
     __u8 bridge_hello_time;


### PR DESCRIPTION
This commit fixes a race condition where the list of interfaces given on add_bridge command is incorrect. Between the moment where the list of interfaces belonging to a bridge and the moment where mstpd receives and manages the message the list of interfaces belonging to the bridge can change. That leads mstpd to send BPDU packets on incorrect list of interfaces that can lead to misbehavior of the protocol. To fix the issue the list of interfaces belonging to the bridge is get by the mstpd daemon and not by the client (mstpcli  or other).
