### PR TITLE
replace custom dont_txmt and bpdu_filter_port with enableBPDU{rx,tx}

### DIFF
--- a/ctl_main.c
+++ b/ctl_main.c
@@ -155,6 +155,7 @@ typedef enum {
     PARAM_RESTRTCN,
     PARAM_PORTHELLOTIME,
     PARAM_DISPUTED,
+    PARAM_ENABLEBPDURX,
     PARAM_BPDUGUARDPORT,
     PARAM_BPDUGUARDERROR,
     PARAM_BPDUFILTERPORT,
@@ -712,6 +713,7 @@ static const cmd_param_t cist_port_params[] = {
     { PARAM_RESTRTCN,       "restricted-TCN" },
     { PARAM_PORTHELLOTIME,  "port-hello-time" },
     { PARAM_DISPUTED,       "disputed" },
+    { PARAM_ENABLEBPDURX,   "enable-bpdu-rx" },
     { PARAM_BPDUGUARDPORT,  "bpdu-guard-port" },
     { PARAM_BPDUGUARDERROR, "bpdu-guard-error" },
     { PARAM_BPDUFILTERPORT, "bpdu-filter-port" },
@@ -786,6 +788,8 @@ static int do_showport_fmt_plain(const CIST_PortStatus *s,
                        BOOL_STR(s->restricted_tcn));
                 printf("  port hello time    %-23hhu ", s->port_hello_time);
                 printf("disputed             %s\n", BOOL_STR(s->disputed));
+                printf("  enable BPDU rx       %s\n",
+                       BOOL_STR(s->enable_bpdu_rx));
                 printf("  bpdu guard port    %-23s ",
                        BOOL_STR(s->bpdu_guard_port));
                 printf("bpdu guard error     %s\n",
@@ -794,9 +798,7 @@ static int do_showport_fmt_plain(const CIST_PortStatus *s,
                        BOOL_STR(s->network_port));
                 printf("BA inconsistent      %s\n",
                        BOOL_STR(s->ba_inconsistent));
-                printf("  bpdu filter port   %-23s ",
-                       BOOL_STR(s->bpdu_filter_port));
-                printf("Num RX BPDU Filtered %u\n", s->num_rx_bpdu_filtered);
+                printf("  Num RX BPDU Filtered %u\n", s->num_rx_bpdu_filtered);
                 printf("  Num TX BPDU        %-23u ", s->num_tx_bpdu);
                 printf("Num TX TCN           %u\n", s->num_tx_tcn);
                 printf("  Num RX BPDU        %-23u ", s->num_rx_bpdu);
@@ -897,6 +899,9 @@ static int do_showport_fmt_plain(const CIST_PortStatus *s,
         case PARAM_DISPUTED:
             printf("%s\n", BOOL_STR(s->disputed));
             break;
+        case PARAM_ENABLEBPDURX:
+            printf("%s\n", BOOL_STR(s->enable_bpdu_rx));
+            break;
         case PARAM_BPDUGUARDPORT:
             printf("%s\n", BOOL_STR(s->bpdu_guard_port));
             break;
@@ -904,7 +909,7 @@ static int do_showport_fmt_plain(const CIST_PortStatus *s,
             printf("%s\n", BOOL_STR(s->bpdu_guard_error));
             break;
         case PARAM_BPDUFILTERPORT:
-            printf("%s\n", BOOL_STR(s->bpdu_filter_port));
+            printf("%s\n", BOOL_STR(!s->enable_bpdu_rx));
             break;
         case PARAM_NETWORKPORT:
             printf("%s\n", BOOL_STR(s->network_port));
@@ -1016,12 +1021,12 @@ static int do_showport_fmt_json(const CIST_PortStatus *s,
                        s->port_hello_time);
                 printf("\"disputed\":\"%s\",",
                        BOOL_STR(s->disputed));
+                printf("\"enable-bpdu-rx\":\"%s\",",
+                       BOOL_STR(s->enable_bpdu_rx));
                 printf("\"bpdu-guard-port\":\"%s\",",
                        BOOL_STR(s->bpdu_guard_port));
                 printf("\"bpdu-guard-error\":\"%s\",",
                        BOOL_STR(s->bpdu_guard_error));
-                printf("\"bpdu-filter-port\":\"%s\",",
-                       BOOL_STR(s->bpdu_filter_port));
                 printf("\"network-port\":\"%s\",",
                        BOOL_STR(s->network_port));
                 printf("\"ba-inconsistent\":\"%s\",",
@@ -1666,6 +1671,17 @@ static int cmd_setportrestrtcn(int argc, char *const *argv)
     return set_port_cfg(restricted_tcn, getyesno(argv[3], "yes", "no"));
 }
 
+static int cmd_setportenablebpdurx(int argc, char *const *argv)
+{
+    int br_index = get_index(argv[1], "bridge");
+    if (0 > br_index)
+        return br_index;
+    int port_index = get_index(argv[2], "port");
+    if (0 > port_index)
+        return port_index;
+    return set_port_cfg(enable_bpdu_rx, getyesno(argv[3], "yes", "no"));
+}
+
 static int cmd_setportbpduguard(int argc, char *const *argv)
 {
     int br_index = get_index(argv[1], "bridge");
@@ -1685,7 +1701,7 @@ static int cmd_setportbpdufilter(int argc, char *const *argv)
     int port_index = get_index(argv[2], "port");
     if (0 > port_index)
         return port_index;
-    return set_port_cfg(bpdu_filter_port, getyesno(argv[3], "yes", "no"));
+    return set_port_cfg(enable_bpdu_rx, !getyesno(argv[3], "yes", "no"));
 }
 
 static int cmd_setportnetwork(int argc, char *const *argv)
@@ -2278,6 +2294,8 @@ static const struct command commands[] =
     {3, 0, "setportrestrtcn", cmd_setportrestrtcn,
      "<bridge> <port> {yes|no}",
      "Restrict port ability to propagate received TCNs"},
+    {3, 0, "setportenablebpdurx", cmd_setportenablebpdurx,
+     "<bridge> <port> {yes|no}", "Disable/Enable receiving BPDUs"},
     {2, 0, "portmcheck", cmd_portmcheck,
      "<bridge> <port>", "Try to get back from STP to rapid (RSTP/MSTP) mode"},
     {3, 0, "setbpduguard", cmd_setportbpduguard,
@@ -2294,7 +2312,7 @@ static const struct command commands[] =
     {3, 0, "setportdonttxmt", cmd_setportdonttxmt,
      "<bridge> <port> {yes|no}", "Disable/Enable sending BPDU"},
     {3, 0, "setportbpdufilter", cmd_setportbpdufilter,
-     "<bridge> <port> {yes|no}", "Set BPDU filter state"},
+     "<bridge> <port> {yes|no}", "Set BPDU filter state (deprecated)"},
 
     /* Other */
     {1, 0, "debuglevel", cmd_debuglevel, "<level>", "Level of verbosity"},

--- a/ctl_main.c
+++ b/ctl_main.c
@@ -156,6 +156,7 @@ typedef enum {
     PARAM_PORTHELLOTIME,
     PARAM_DISPUTED,
     PARAM_ENABLEBPDURX,
+    PARAM_ENABLEBPDUTX,
     PARAM_BPDUGUARDPORT,
     PARAM_BPDUGUARDERROR,
     PARAM_BPDUFILTERPORT,
@@ -714,6 +715,7 @@ static const cmd_param_t cist_port_params[] = {
     { PARAM_PORTHELLOTIME,  "port-hello-time" },
     { PARAM_DISPUTED,       "disputed" },
     { PARAM_ENABLEBPDURX,   "enable-bpdu-rx" },
+    { PARAM_ENABLEBPDUTX,   "enable-bpdu-tx" },
     { PARAM_BPDUGUARDPORT,  "bpdu-guard-port" },
     { PARAM_BPDUGUARDERROR, "bpdu-guard-error" },
     { PARAM_BPDUFILTERPORT, "bpdu-filter-port" },
@@ -788,8 +790,10 @@ static int do_showport_fmt_plain(const CIST_PortStatus *s,
                        BOOL_STR(s->restricted_tcn));
                 printf("  port hello time    %-23hhu ", s->port_hello_time);
                 printf("disputed             %s\n", BOOL_STR(s->disputed));
-                printf("  enable BPDU rx       %s\n",
+                printf("  enable BPDU rx       %-23s ",
                        BOOL_STR(s->enable_bpdu_rx));
+                printf("enable BPDU tx       %s\n",
+                       BOOL_STR(s->enable_bpdu_tx));
                 printf("  bpdu guard port    %-23s ",
                        BOOL_STR(s->bpdu_guard_port));
                 printf("bpdu guard error     %s\n",
@@ -901,6 +905,9 @@ static int do_showport_fmt_plain(const CIST_PortStatus *s,
             break;
         case PARAM_ENABLEBPDURX:
             printf("%s\n", BOOL_STR(s->enable_bpdu_rx));
+            break;
+        case PARAM_ENABLEBPDUTX:
+            printf("%s\n", BOOL_STR(s->enable_bpdu_tx));
             break;
         case PARAM_BPDUGUARDPORT:
             printf("%s\n", BOOL_STR(s->bpdu_guard_port));
@@ -1023,6 +1030,8 @@ static int do_showport_fmt_json(const CIST_PortStatus *s,
                        BOOL_STR(s->disputed));
                 printf("\"enable-bpdu-rx\":\"%s\",",
                        BOOL_STR(s->enable_bpdu_rx));
+                printf("\"enable-bpdu-tx\":\"%s\",",
+                       BOOL_STR(s->enable_bpdu_tx));
                 printf("\"bpdu-guard-port\":\"%s\",",
                        BOOL_STR(s->bpdu_guard_port));
                 printf("\"bpdu-guard-error\":\"%s\",",
@@ -1682,6 +1691,17 @@ static int cmd_setportenablebpdurx(int argc, char *const *argv)
     return set_port_cfg(enable_bpdu_rx, getyesno(argv[3], "yes", "no"));
 }
 
+static int cmd_setportenablebpdutx(int argc, char *const *argv)
+{
+    int br_index = get_index(argv[1], "bridge");
+    if (0 > br_index)
+        return br_index;
+    int port_index = get_index(argv[2], "port");
+    if (0 > port_index)
+        return port_index;
+    return set_port_cfg(enable_bpdu_tx, getyesno(argv[3], "yes", "no"));
+}
+
 static int cmd_setportbpduguard(int argc, char *const *argv)
 {
     int br_index = get_index(argv[1], "bridge");
@@ -1723,7 +1743,7 @@ static int cmd_setportdonttxmt(int argc, char *const *argv)
     int port_index = get_index(argv[2], "port");
     if (0 > port_index)
         return port_index;
-    return set_port_cfg(dont_txmt, getyesno(argv[3], "yes", "no"));
+    return set_port_cfg(enable_bpdu_tx, !getyesno(argv[3], "yes", "no"));
 }
 
 static int cmd_settreeportprio(int argc, char *const *argv)
@@ -2296,6 +2316,8 @@ static const struct command commands[] =
      "Restrict port ability to propagate received TCNs"},
     {3, 0, "setportenablebpdurx", cmd_setportenablebpdurx,
      "<bridge> <port> {yes|no}", "Disable/Enable receiving BPDUs"},
+    {3, 0, "setportenablebpdutx", cmd_setportenablebpdutx,
+     "<bridge> <port> {yes|no}", "Disable/Enable sending BPDUs"},
     {2, 0, "portmcheck", cmd_portmcheck,
      "<bridge> <port>", "Try to get back from STP to rapid (RSTP/MSTP) mode"},
     {3, 0, "setbpduguard", cmd_setportbpduguard,
@@ -2310,7 +2332,7 @@ static const struct command commands[] =
     {3, 0, "setportnetwork", cmd_setportnetwork,
      "<bridge> <port> {yes|no}", "Set port network state"},
     {3, 0, "setportdonttxmt", cmd_setportdonttxmt,
-     "<bridge> <port> {yes|no}", "Disable/Enable sending BPDU"},
+     "<bridge> <port> {yes|no}", "Disable/Enable sending BPDU (deprecated)"},
     {3, 0, "setportbpdufilter", cmd_setportbpdufilter,
      "<bridge> <port> {yes|no}", "Set BPDU filter state (deprecated)"},
 

--- a/mstp.c
+++ b/mstp.c
@@ -298,11 +298,11 @@ bool MSTP_IN_port_create_and_add_tail(port_t *prt, __u16 portno)
     assign(prt->ExternalPortPathCost, MAX_PATH_COST); /* 13.37.1 */
     prt->AdminEdgePort = false; /* 13.25 */
     prt->AutoEdge = true;       /* 13.25 */
+    prt->enableBPDUrx = true;
     prt->BpduGuardPort = false;
     prt->BpduGuardError = false;
     prt->NetworkPort = false;
     prt->dontTxmtBpdu = false;
-    prt->bpduFilterPort = false;
     prt->deleted = false;
 
     port_default_internal_vars(prt);
@@ -592,7 +592,7 @@ void MSTP_IN_rx_bpdu(port_t *prt, bpdu_t *bpdu, int size)
         return;
     }
 
-    if(prt->bpduFilterPort)
+    if(!prt->enableBPDUrx)
     {
         LOG_PRTNAME(br, prt,
                    "Received BPDU on BPDU Filtered Port - discarded");
@@ -1018,6 +1018,7 @@ void MSTP_IN_get_cist_port_status(port_t *prt, CIST_PortStatus *status)
     status->restricted_tcn = prt->restrictedTcn;
     status->role = cist->role;
     status->disputed = cist->disputed;
+    status->enable_bpdu_rx = prt->enableBPDUrx;
     assign(status->admin_internal_port_path_cost,
            cist->AdminInternalPortPathCost);
     assign(status->internal_port_path_cost, cist->InternalPortPathCost);
@@ -1025,7 +1026,6 @@ void MSTP_IN_get_cist_port_status(port_t *prt, CIST_PortStatus *status)
     status->bpdu_guard_error = prt->BpduGuardError;
     status->network_port = prt->NetworkPort;
     status->ba_inconsistent = prt->BaInconsistent;
-    status->bpdu_filter_port = prt->bpduFilterPort;
     status->num_rx_bpdu_filtered = prt->num_rx_bpdu_filtered;
     status->num_rx_bpdu = prt->num_rx_bpdu;
     status->num_rx_tcn = prt->num_rx_tcn;
@@ -1174,6 +1174,16 @@ int MSTP_IN_set_cist_port_config(port_t *prt, CIST_PortConfig *cfg)
         }
     }
 
+    if(cfg->set_enable_bpdu_rx)
+    {
+        if (prt->enableBPDUrx != cfg->enable_bpdu_rx)
+        {
+            prt->enableBPDUrx = cfg->enable_bpdu_rx;
+            prt->num_rx_bpdu_filtered = 0;
+            INFO_PRTNAME(br, prt,"enableBPDUrx new=%d", prt->enableBPDUrx);
+        }
+    }
+
     if(cfg->set_bpdu_guard_port)
     {
         if(prt->BpduGuardPort != cfg->bpdu_guard_port)
@@ -1207,16 +1217,6 @@ int MSTP_IN_set_cist_port_config(port_t *prt, CIST_PortConfig *cfg)
         {
             prt->dontTxmtBpdu = cfg->dont_txmt;
             INFO_PRTNAME(br, prt, "donttxmt new=%d", prt->dontTxmtBpdu);
-        }
-    }
-
-    if(cfg->set_bpdu_filter_port)
-    {
-        if (prt->bpduFilterPort != cfg->bpdu_filter_port)
-        {
-            prt->bpduFilterPort = cfg->bpdu_filter_port;
-            prt->num_rx_bpdu_filtered = 0;
-            INFO_PRTNAME(br, prt,"bpduFilterPort new=%d", prt->bpduFilterPort);
         }
     }
 
@@ -3302,7 +3302,7 @@ static bool PTSM_run(port_t *prt, bool dry_run)
             if(!(prt->txCount < prt->bridge->Transmit_Hold_Count))
                 return false;
 
-            if(prt->bpduFilterPort)
+            if(!prt->enableBPDUrx)
                 return false;
 
             if(prt->sendRSTP)

--- a/mstp.c
+++ b/mstp.c
@@ -299,10 +299,10 @@ bool MSTP_IN_port_create_and_add_tail(port_t *prt, __u16 portno)
     prt->AdminEdgePort = false; /* 13.25 */
     prt->AutoEdge = true;       /* 13.25 */
     prt->enableBPDUrx = true;
+    prt->enableBPDUtx = true;
     prt->BpduGuardPort = false;
     prt->BpduGuardError = false;
     prt->NetworkPort = false;
-    prt->dontTxmtBpdu = false;
     prt->deleted = false;
 
     port_default_internal_vars(prt);
@@ -1019,6 +1019,7 @@ void MSTP_IN_get_cist_port_status(port_t *prt, CIST_PortStatus *status)
     status->role = cist->role;
     status->disputed = cist->disputed;
     status->enable_bpdu_rx = prt->enableBPDUrx;
+    status->enable_bpdu_tx = prt->enableBPDUtx;
     assign(status->admin_internal_port_path_cost,
            cist->AdminInternalPortPathCost);
     assign(status->internal_port_path_cost, cist->InternalPortPathCost);
@@ -1183,6 +1184,15 @@ int MSTP_IN_set_cist_port_config(port_t *prt, CIST_PortConfig *cfg)
             INFO_PRTNAME(br, prt,"enableBPDUrx new=%d", prt->enableBPDUrx);
         }
     }
+    
+    if(cfg->set_enable_bpdu_tx)
+    {
+        if(prt->enableBPDUtx != cfg->enable_bpdu_tx)
+        {
+            prt->enableBPDUtx = cfg->enable_bpdu_tx;
+            INFO_PRTNAME(br, prt, "enableBPDUtx new=%d", prt->enableBPDUtx);
+        }
+    }
 
     if(cfg->set_bpdu_guard_port)
     {
@@ -1208,15 +1218,6 @@ int MSTP_IN_set_cist_port_config(port_t *prt, CIST_PortConfig *cfg)
                 INFO_PRTNAME(br, prt, "Clear Bridge assurance inconsistency");
             }
             changed = true;
-        }
-    }
-
-    if(cfg->set_dont_txmt)
-    {
-        if(prt->dontTxmtBpdu != cfg->dont_txmt)
-        {
-            prt->dontTxmtBpdu = cfg->dont_txmt;
-            INFO_PRTNAME(br, prt, "donttxmt new=%d", prt->dontTxmtBpdu);
         }
     }
 
@@ -2362,7 +2363,7 @@ static void txConfig(port_t *prt)
     bpdu_t b;
     per_tree_port_t *cist = GET_CIST_PTP_FROM_PORT(prt);
 
-    if(prt->deleted || (roleDisabled == cist->role) || prt->dontTxmtBpdu)
+    if(prt->deleted || (roleDisabled == cist->role) || !prt->enableBPDUtx)
         return;
 
     b.protocolIdentifier = 0;
@@ -2423,7 +2424,7 @@ static void txMstp(port_t *prt)
     per_tree_port_t *ptp;
     msti_configuration_message_t *msti_msg;
 
-    if(prt->deleted || (roleDisabled == cist->role) || prt->dontTxmtBpdu)
+    if(prt->deleted || (roleDisabled == cist->role) || !prt->enableBPDUtx)
         return;
 
     b.protocolIdentifier = 0;
@@ -2521,7 +2522,7 @@ static void txTcn(port_t *prt)
     bpdu_t b;
     per_tree_port_t *cist = GET_CIST_PTP_FROM_PORT(prt);
 
-    if(prt->deleted || (roleDisabled == cist->role) || prt->dontTxmtBpdu)
+    if(prt->deleted || (roleDisabled == cist->role) || !prt->enableBPDUtx)
         return;
 
     b.protocolIdentifier = 0;

--- a/mstp.h
+++ b/mstp.h
@@ -473,12 +473,12 @@ typedef struct
     admin_p2p_t AdminP2P; /* 6.4.3 */
     bool AdminEdgePort; /* 13.22.k */
     bool AutoEdge; /* 13.22.m */
+    bool enableBPDUrx;
     bool BpduGuardPort;
     bool BpduGuardError;
     bool NetworkPort;
     bool BaInconsistent;
     bool dontTxmtBpdu;
-    bool bpduFilterPort;
 
     unsigned int rapidAgeingWhile;
     unsigned int brAssuRcvdInfoWhile;
@@ -698,13 +698,13 @@ typedef struct
     bool restricted_tcn;
     port_role_t role;
     bool disputed;
+    bool enable_bpdu_rx;
     bridge_identifier_t designated_regional_root; /* from portPriority */
     __u32 designated_internal_cost; /* from portPriority */
     __u32 admin_internal_port_path_cost; /* not in standard. 0 = auto */
     __u32 internal_port_path_cost; /* not in standard */
     bool bpdu_guard_port;
     bool bpdu_guard_error;
-    bool bpdu_filter_port;
     bool network_port;
     bool ba_inconsistent;
     unsigned int num_rx_bpdu_filtered;
@@ -772,6 +772,9 @@ typedef struct
     bool restricted_tcn;
     bool set_restricted_tcn;
 
+    bool enable_bpdu_rx;
+    bool set_enable_bpdu_rx;
+
     bool bpdu_guard_port;
     bool set_bpdu_guard_port;
 
@@ -780,9 +783,6 @@ typedef struct
 
     bool dont_txmt;
     bool set_dont_txmt;
-
-    bool bpdu_filter_port;
-    bool set_bpdu_filter_port;
 } CIST_PortConfig;
 
 int MSTP_IN_set_cist_port_config(port_t *prt, CIST_PortConfig *cfg);

--- a/mstp.h
+++ b/mstp.h
@@ -474,11 +474,11 @@ typedef struct
     bool AdminEdgePort; /* 13.22.k */
     bool AutoEdge; /* 13.22.m */
     bool enableBPDUrx;
+    bool enableBPDUtx;
     bool BpduGuardPort;
     bool BpduGuardError;
     bool NetworkPort;
     bool BaInconsistent;
-    bool dontTxmtBpdu;
 
     unsigned int rapidAgeingWhile;
     unsigned int brAssuRcvdInfoWhile;
@@ -699,6 +699,7 @@ typedef struct
     port_role_t role;
     bool disputed;
     bool enable_bpdu_rx;
+    bool enable_bpdu_tx;
     bridge_identifier_t designated_regional_root; /* from portPriority */
     __u32 designated_internal_cost; /* from portPriority */
     __u32 admin_internal_port_path_cost; /* not in standard. 0 = auto */
@@ -775,14 +776,15 @@ typedef struct
     bool enable_bpdu_rx;
     bool set_enable_bpdu_rx;
 
+    bool enable_bpdu_tx;
+    bool set_enable_bpdu_tx;
+
     bool bpdu_guard_port;
     bool set_bpdu_guard_port;
 
     bool network_port;
     bool set_network_port;
 
-    bool dont_txmt;
-    bool set_dont_txmt;
 } CIST_PortConfig;
 
 int MSTP_IN_set_cist_port_config(port_t *prt, CIST_PortConfig *cfg);

--- a/utils/bash_completion
+++ b/utils/bash_completion
@@ -14,10 +14,10 @@ _mstpctl()
                 setfid2mstid setmaxage setfdelay setmaxhops setforcevers \
                 settxholdcount settreeprio setportpathcost setportadminedge \
                 setportautoedge setportp2p setportrestrrole setportrestrtcn \
-                setenablebpdurx setbpduguard settreeportprio settreeportcost \
-                showbridge showmstilist showmstconfid showvid2fid \
-                showfid2mstid showport showportdetail showtree showtreeport \
-                sethello setageing setportnetwork" -- "$cur" ) )
+                setenablebpdurx setenablebpdutx setbpduguard settreeportprio \
+                settreeportcost showbridge showmstilist showmstconfid \
+                showvid2fid showfid2mstid showport showportdetail showtree \
+               showtreeport sethello setageing setportnetwork" -- "$cur" ) )
             ;;
         2)
             case $command in
@@ -47,7 +47,8 @@ _mstpctl()
         4)
             case $command in
                 setportadminedge|setportautoedge|setportrestrrole|\
-                setportrestrtcn|setportenablebpdurx|setbpduguard|setportnetwork)
+                setportrestrtcn|setportenablebpdurx|setportenablebpdutx|\
+                setbpduguard|setportnetwork)
                     COMPREPLY=( $( compgen -W 'yes no' -- "$cur" ) )
                     ;;
                 setportp2p)

--- a/utils/bash_completion
+++ b/utils/bash_completion
@@ -14,10 +14,10 @@ _mstpctl()
                 setfid2mstid setmaxage setfdelay setmaxhops setforcevers \
                 settxholdcount settreeprio setportpathcost setportadminedge \
                 setportautoedge setportp2p setportrestrrole setportrestrtcn \
-                setbpduguard settreeportprio settreeportcost showbridge \
-                showmstilist showmstconfid showvid2fid showfid2mstid showport \
-                showportdetail showtree showtreeport sethello \
-                setageing setportnetwork setportbpdufilter" -- "$cur" ) )
+                setenablebpdurx setbpduguard settreeportprio settreeportcost \
+                showbridge showmstilist showmstconfid showvid2fid \
+                showfid2mstid showport showportdetail showtree showtreeport \
+                sethello setageing setportnetwork" -- "$cur" ) )
             ;;
         2)
             case $command in
@@ -47,7 +47,7 @@ _mstpctl()
         4)
             case $command in
                 setportadminedge|setportautoedge|setportrestrrole|\
-                setportrestrtcn|setbpduguard|setportnetwork|setportbpdufilter)
+                setportrestrtcn|setportenablebpdurx|setbpduguard|setportnetwork)
                     COMPREPLY=( $( compgen -W 'yes no' -- "$cur" ) )
                     ;;
                 setportp2p)

--- a/utils/ifupdown.sh.in
+++ b/utils/ifupdown.sh.in
@@ -225,6 +225,17 @@ if [ "$MODE" = 'start' ]; then
     done
   fi
 
+  if [ "$IF_MSTPCTL_ENABLEBPDUTX" ]; then
+    portenablebpdutxs="$(echo "$IF_MSTPCTL_ENABLEBPDUTX" | tr '\n' ' ' | tr -s ' ')"
+    for portenablebpdutx in $portenablebpdutxs; do
+      port="$(echo "$portenablebpdutx" | cut -d '=' -f1)"
+      enablebpdutx="$(echo "$portenablebpdutx" | cut -d '=' -f2)"
+      if [ -n "$port" ] && [ -n "$enablebpdutx" ]; then
+        "$mstpctl" setenablebpdutx "$IFACE" "$port" "$enablebpdutx"
+      fi
+    done
+  fi
+
   if [ "$IF_MSTPCTL_BPDUGUARD" ]; then
     portbpduguards="$(echo "$IF_MSTPCTL_BPDUGUARD" | tr '\n' ' ' | tr -s ' ')"
     for portbpduguard in $portbpduguards; do

--- a/utils/ifupdown.sh.in
+++ b/utils/ifupdown.sh.in
@@ -214,6 +214,17 @@ if [ "$MODE" = 'start' ]; then
     done
   fi
 
+  if [ "$IF_MSTPCTL_ENABLEBPDURX" ]; then
+    portenablebpdurxs="$(echo "$IF_MSTPCTL_ENABLEBPDURX" | tr '\n' ' ' | tr -s ' ')"
+    for portenablebpdurx in $portenablebpdurxs; do
+      port="$(echo "$portenablebpdurx" | cut -d '=' -f1)"
+      enablebpdurx="$(echo "$portenablebpdurx" | cut -d '=' -f2)"
+      if [ -n "$port" ] && [ -n "$enablebpdurx" ]; then
+        "$mstpctl" setenablebpdurx "$IFACE" "$port" "$enablebpdurx"
+      fi
+    done
+  fi
+
   if [ "$IF_MSTPCTL_BPDUGUARD" ]; then
     portbpduguards="$(echo "$IF_MSTPCTL_BPDUGUARD" | tr '\n' ' ' | tr -s ' ')"
     for portbpduguard in $portbpduguards; do

--- a/utils/mstpctl-utils-interfaces.5
+++ b/utils/mstpctl-utils-interfaces.5
@@ -134,6 +134,10 @@ Enables/disables the restrictions on the \fIport\fP's ability to propagate recei
 Enables/disables processing of received BPDUs on a \fIport\fP,
 default is yes.
 .TP
+.BI mstpctl_portenablebpdutx " port yes|no"
+Enables/disables transmission of BPDUs on a \fIport\fP,
+default is yes.
+.TP
 .BI mstpctl_bpduguard " port yes|no"
 Enables/disables the bpduguard configuration of the \fIport\fP, default is no.
 .TP

--- a/utils/mstpctl-utils-interfaces.5
+++ b/utils/mstpctl-utils-interfaces.5
@@ -52,12 +52,12 @@ iface br0 inet static
     mstpctl_portp2p swp1=no swp2=no
     mstpctl_portrestrrole swp1=no swp2=no
     mstpctl_bpduguard swp1=no swp2=no swp4=yes
+    mstpctl_portenablebpdurx swp4=no
     mstpctl_portrestrtcn swp1=no swp2=no
     mstpctl_treeprio 8
     mstpctl_treeportprio swp3=8
     mstpctl_hello 2
     mstpctl_portnetwork swp1=no
-    mstpctl_portbpdufilter swp4=yes
 
 .EE
 .SH IFACE OPTIONS
@@ -130,6 +130,10 @@ default is no (i.e. no restrictions on the port's role).
 .BI mstpctl_portrestrtcn " port yes|no"
 Enables/disables the restrictions on the \fIport\fP's ability to propagate received topology change notification, default is no (i.e. no restrictions on the TCN propagation).
 .TP
+.BI mstpctl_portenablebpdurx " port yes|no"
+Enables/disables processing of received BPDUs on a \fIport\fP,
+default is yes.
+.TP
 .BI mstpctl_bpduguard " port yes|no"
 Enables/disables the bpduguard configuration of the \fIport\fP, default is no.
 .TP
@@ -147,7 +151,7 @@ Enables/disables the bridge assurance capability for a \fIport\fP,
 default is no.
 .TP
 .BI mstpctl_portbpdufilter " port yes|no"
-Enables/disables the bridge BPDU filter capability for a \fIport\fP,
+(Deprecated) Enables/disables the bridge BPDU filter capability for a \fIport\fP,
 default is no.
 .RE
 .SH FILES

--- a/utils/mstpctl.8
+++ b/utils/mstpctl.8
@@ -72,6 +72,9 @@ Enables/disables the restrictions on the <port>'s ability to take root role in <
 .B mstpctl setportrestrtcn <bridge> <port> {yes|no}
 Enables/disables the restrictions on the <port>'s ability to propagate received topology change notification in <bridge>, default is no (i.e. no restrictions on the TCN propagation).
 
+.B mstpctl setportenablebpdurx <bridge> <port> {yes|no}
+Enables/disables processing of received BPDUs on port <port> in bridge <bridge>, default is yes.
+
 .B mstpctl setbpduguard <bridge> <port> {yes|no}
 Enables/disables the bpduguard configuration of the <port> in <bridge>, default is no.
 
@@ -89,7 +92,7 @@ Enables/disables the bridge assurance capability for a <port> in <bridge>,
 default is no.
 
 .B mstpctl setportbpdufilter <bridge> <port> {yes|no}
-Enables/disables the BPDU filter capability for a port <port> in
+(Deprecated) Enables/disables the BPDU filter capability for a port <port> in
 bridge <bridge>, i.e. discard any ingress BPDUs and do not issue any
 BPDUs for this port. The default is no.
 

--- a/utils/mstpctl.8
+++ b/utils/mstpctl.8
@@ -75,6 +75,9 @@ Enables/disables the restrictions on the <port>'s ability to propagate received 
 .B mstpctl setportenablebpdurx <bridge> <port> {yes|no}
 Enables/disables processing of received BPDUs on port <port> in bridge <bridge>, default is yes.
 
+.B mstpctl setportenablebpdutx <bridge> <port> {yes|no}
+Enables/disables transmission of BPDUs on port <port> in bridge <bridge>, default is yes.
+
 .B mstpctl setbpduguard <bridge> <port> {yes|no}
 Enables/disables the bpduguard configuration of the <port> in <bridge>, default is no.
 


### PR DESCRIPTION
Replace custom `donttxmt` and `bpdufilterport` options with standard `enableBPDUtx` and `enableBPDUtx`, as defined in the optional L2GP extension for MSTP.

While we don't implement L2GP that shouldn't stop is from supporting parts of it.

To not break existing setups, still allow setting the old options, but translate this to setting the appropriate standard option to the inverse value.

This also indirectly fixes the issue that there was no way of retrieving the current configuration of `donttxmt`, as the current value of `enableBPDUtx` is now available.