### PR TITLE
ubus: allow dynamic bridge stp configuration over ubus

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,11 +5,42 @@ on: [ push, pull_request ]
 jobs:
   linux:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        config:
+          - name: "default"
+            flags: "--enable-devel"
+            install_ubus: false
+          - name: "with-ubus"
+            flags: "--enable-devel --enable-ubus"
+            install_ubus: true
     steps:
-    - uses: actions/checkout@v2
-    - name: build
+    - uses: actions/checkout@v6
+    - name: Install ubus dependencies
+      if: matrix.config.install_ubus
       shell: bash
-      run: ./autogen.sh && ./configure --enable-devel && make V=s
+      run: |
+        sudo apt update
+        sudo apt install -y libjson-c-dev cmake liblua5.1-0-dev lua5.1
+
+        # Build libubox
+        git clone https://git.openwrt.org/project/libubox.git
+        cd libubox
+        cmake .
+        make
+        sudo make install
+        cd ..
+
+        # Build libubus
+        git clone https://git.openwrt.org/project/ubus.git
+        cd ubus
+        cmake .
+        make
+        sudo make install
+        sudo ldconfig
+    - name: build (${{ matrix.config.name }})
+      shell: bash
+      run: ./autogen.sh && ./configure ${{ matrix.config.flags }} && make V=s
     - name: shellcheck
       shell: bash
       run: shellcheck utils/ifupdown.sh.in utils/mstp_config_bridge.in utils/mstpctl-utils-functions.sh

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,6 +1,6 @@
 ACLOCAL_AMFLAGS = -I m4
 
-sbin_PROGRAMS = mstpd mstpctl
+sbin_PROGRAMS = mstpd
 
 mstpd_SOURCES = \
 	main.c epoll_loop.c epoll_loop.h clock_gettime.h brmon.c \
@@ -9,8 +9,13 @@ mstpd_SOURCES = \
 	netif_utils.h ctl_socket_server.c ctl_socket_server.h hmac_md5.c \
 	list.h log.h driver_deps.c
 
+if ENABLE_UBUS
+mstpd_SOURCES += ubus.c ubus.h bridge_config.c bridge_config.h
+else
 mstpctl_SOURCES = \
-	ctl_main.c ctl_socket_client.c ctl_socket_client.h ctl_functions.h
+        ctl_main.c ctl_socket_client.c ctl_socket_client.h ctl_functions.h
+sbin_PROGRAMS += mstpctl
+endif
 
 mstpd_CFLAGS = \
 	-Os -Wall -D_REENTRANT -D__LINUX__ -I. \
@@ -18,7 +23,11 @@ mstpd_CFLAGS = \
 if ENABLE_DEVEL
   mstpd_CFLAGS += -g3 -O0 -Werror
 endif
+if ENABLE_UBUS
+mstpd_LDADD = $(LIBUBOX_LIBS) $(LIBUBUS_LIBS)
+else
 mstpctl_CFLAGS = $(mstpd_CFLAGS)
+endif
 
 EXTRA_DIST = bridge-stp.in utils/ifupdown.sh.in utils/mstp_config_bridge.in \
 	utils/mstpd.service.in utils/bash_completion utils/nm-dispatcher.in \

--- a/README.ubus.md
+++ b/README.ubus.md
@@ -1,0 +1,83 @@
+# MSTPD ubus Support
+
+## What is ubus?
+
+ubus (OpenWrt micro bus architecture) is a lightweight inter-process communication (IPC) system used primarily in OpenWrt. It provides:
+
+- **Object-oriented RPC**: Services register objects with methods that can be called by other processes
+- **Event notifications**: Publish/subscribe mechanism for system events
+- **Language-agnostic**: Can be accessed from shell scripts, C programs, Lua, and other languages
+- **Low overhead**: Designed for embedded systems with limited resources
+
+In the context of mstpd, ubus allows other system components and user scripts to dynamically configure and manage spanning tree bridges without restarting the daemon or editing configuration files.
+
+## Build Configuration
+
+ubus support is **disabled by default** and must be explicitly enabled during the build configuration:
+
+```bash
+./configure --enable-ubus
+make
+```
+
+### Dependencies
+
+When ubus support is enabled, the following libraries are required:
+
+- **libubox** - Core OpenWrt utility library (provides data structures, event loop helpers)
+- **libubus** - OpenWrt ubus IPC library (provides RPC and messaging functionality)
+
+If these libraries are not found, the configure script will fail with an error message. To build without ubus support, simply omit the `--enable-ubus` flag.
+
+## ubus Interface
+
+When compiled with ubus support, mstpd registers the `mstpd` ubus object with the following methods:
+
+### 1. add_bridge
+
+Configures and creates a bridge with STP/RSTP/MSTP parameters.
+
+**Parameters:**
+- `name` (string, required) - Bridge interface name
+- `proto` (string, optional) - Protocol version: "stp", "rstp", or "mstp" (default: "rstp")
+- `forward_delay` (int32, optional) - Bridge forward delay in seconds
+- `max_age` (int32, optional) - Maximum age in seconds
+- `ageing_time` (int32, optional) - MAC address ageing time in seconds
+
+**Example:**
+```bash
+ubus call mstpd add_bridge '{"name":"br-lan", "proto":"rstp", "forward_delay":15, "max_age":20}'
+```
+
+**Important:** The bridge interface must already exist in the system before calling this method. Create it first with `ip link add <name> type bridge`.
+
+### 2. delete_bridge
+
+Removes a bridge from mstpd management and stops spanning tree operation.
+
+**Parameters:**
+- `name` (string, required) - Bridge interface name
+
+**Example:**
+```bash
+ubus call mstpd delete_bridge '{"name":"br-lan"}'
+```
+
+**Note:** This does not delete the bridge interface itself from the system, only removes it from mstpd's management.
+
+### Listing available ubus objects
+
+```bash
+# See all registered ubus objects
+ubus list
+
+# See methods available on mstpd
+ubus list mstpd
+
+# Get detailed method signatures
+ubus -v list mstpd
+```
+
+## Acknowledgements
+
+This ubus integration is based on the ustp daemon originally developed by Felix Fietkau <nbd@nbd.name> (2021) for OpenWrt.

--- a/bridge_config.c
+++ b/bridge_config.c
@@ -1,0 +1,53 @@
+/*
+ * ustp - OpenWrt STP/RSTP/MSTP daemon
+ * Copyright (C) 2021 Felix Fietkau <nbd@nbd.name>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2
+ * as published by the Free Software Foundation
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+#include <string.h>
+
+#include <libubox/avl-cmp.h>
+#include <libubox/utils.h>
+
+#include "bridge_config.h"
+
+AVL_TREE(bridge_config, avl_strcmp, false, NULL);
+
+static uint32_t bridge_config_timestamp(void)
+{
+    struct timespec ts;
+
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+
+    return ts.tv_sec;
+}
+
+struct bridge_config *bridge_config_get(const char *name, bool create)
+{
+    struct bridge_config *cfg;
+    char *name_buf;
+
+    cfg = avl_find_element(&bridge_config, name, cfg, node);
+    if(cfg)
+        goto out;
+
+    if(!create)
+        return NULL;
+
+    cfg = calloc_a(sizeof(*cfg), &name_buf, strlen(name) + 1);
+    cfg->node.key = strcpy(name_buf, name);
+    avl_insert(&bridge_config, &cfg->node);
+
+out:
+    cfg->timestamp = bridge_config_timestamp();
+
+    return cfg;
+}
+

--- a/bridge_config.h
+++ b/bridge_config.h
@@ -1,0 +1,31 @@
+/*
+ * ustp - OpenWrt STP/RSTP/MSTP daemon
+ * Copyright (C) 2021 Felix Fietkau <nbd@nbd.name>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2
+ * as published by the Free Software Foundation
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+#ifndef __CONFIG_H
+#define __CONFIG_H
+
+#include <libubox/avl.h>
+#include <stdint.h>
+#include "mstp.h"
+
+extern struct avl_tree bridge_config;
+
+struct bridge_config {
+    struct avl_node node;
+    uint32_t timestamp;
+    CIST_BridgeConfig config;
+};
+
+struct bridge_config *bridge_config_get(const char *name, bool create);
+
+#endif

--- a/bridge_track.c
+++ b/bridge_track.c
@@ -31,6 +31,7 @@
 #include <netinet/in.h>
 #include <linux/if_bridge.h>
 #include <asm/byteorder.h>
+#include <dirent.h>
 
 #include "bridge_ctl.h"
 #include "ctl_functions.h"
@@ -631,6 +632,22 @@ void MSTP_OUT_shutdown_port(port_t *prt)
         ERROR_PRTNAME(prt->bridge, prt, "Couldn't shutdown port");
 }
 
+static int not_dot_dotdot(const struct dirent *entry)
+{
+        const char *n = entry->d_name;
+
+        return strcmp(n, ".") || strcmp(n, "..");
+}
+
+static int get_port_list(const char *br_ifname, struct dirent ***namelist)
+{
+        char buf[256];
+
+        snprintf(buf, sizeof(buf), SYSFS_CLASS_NET "/%.230s/brif", br_ifname);
+
+        return scandir(buf, namelist, not_dot_dotdot, versionsort);
+}
+
 /* User interface commands */
 
 #define CTL_CHECK_BRIDGE                                       \
@@ -917,6 +934,90 @@ int CTL_del_bridges(int *br_array)
     }
 
     return 0;
+}
+
+int bridge_create(int bridge_idx, CIST_BridgeConfig *cfg)
+{
+    struct dirent **namelist;
+    int *port_list, n_ports;
+    bridge_t *br, *other_br;
+    port_t *port, *tmp;
+    int flags;
+    bool found;
+    int i;
+
+    br = find_br(bridge_idx);
+    if(!br)
+        br = create_br(bridge_idx);
+    if(!br)
+        return -1;
+
+    MSTP_IN_set_cist_bridge_config(br, cfg);
+
+    flags = get_flags(br->sysdeps.name);
+    if(flags >= 0)
+        set_br_up(br, !!(flags & IFF_UP));
+
+    n_ports = get_port_list(br->sysdeps.name, &namelist);
+    port_list = alloca(n_ports * sizeof(*port_list));
+
+    for(i = 0; i < n_ports; i++)
+    {
+        port_list[i] = if_nametoindex(namelist[i]->d_name);
+        free(namelist[i]);
+    }
+    free(namelist);
+
+    list_for_each_entry_safe(port, tmp, &br->ports, br_list)
+    {
+        found = false;
+        for(i = 0; i < n_ports; i++)
+        {
+            if(port->sysdeps.if_index != port_list[i])
+                continue;
+            found = true;
+            break;
+        }
+
+        if(found)
+            continue;
+
+        delete_if(port);
+    }
+
+    for(i = 0; i < n_ports; i++)
+    {
+        port = find_if(br, port_list[i]);
+        if(port)
+            continue;
+
+        list_for_each_entry(other_br, &bridges, list)
+        {
+            if(br == other_br)
+                continue;
+
+            delete_if_byindex(other_br, port_list[i]);
+        }
+
+        port = find_if(br, port_list[i]);
+        if(!port)
+            port = create_if(br, port_list[i]);
+        if(!port)
+            continue;
+
+        flags = get_flags(port->sysdeps.name);
+        if(flags < 0)
+            continue;
+
+        set_if_up(port, !(~flags & (IFF_UP | IFF_RUNNING)));
+    }
+
+    return 0;
+}
+
+void bridge_delete(int index)
+{
+    delete_br_byindex(index);
 }
 
 int bridge_track_fini(void)

--- a/bridge_track.h
+++ b/bridge_track.h
@@ -21,6 +21,10 @@
 #ifndef MSTPD_BRIDGE_TRACK_H
 #define MSTPD_BRIDGE_TRACK_H
 
+#include "mstp.h"
+
+int bridge_create(int bridge_idx, CIST_BridgeConfig *cfg);
+void bridge_delete(int bridge_idx);
 int bridge_track_fini(void);
 
 #endif

--- a/configure.ac
+++ b/configure.ac
@@ -86,6 +86,30 @@ AC_SEARCH_LIBS([clock_gettime], [rt])
 AC_CHECK_TYPES(struct timespec)
 AC_CHECK_FUNCS(clock_gettime)
 
+# Optional ubus support
+AC_ARG_ENABLE([ubus],
+	[AC_HELP_STRING([--enable-ubus], [enable ubus support (default: disabled)])],
+	[enable_ubus=$enableval],
+	[enable_ubus=no])
+
+AS_IF([test "x$enable_ubus" = "xyes"], [
+	# Check for libubox
+	AC_CHECK_LIB([ubox], [uloop_init],
+		[LIBUBOX_LIBS="-lubox"],
+		[AC_MSG_ERROR([libubox not found. Please install libubox development package or compile without ubus support.])])
+
+	# Check for libubus
+	AC_CHECK_LIB([ubus], [ubus_connect],
+		[LIBUBUS_LIBS="-lubus"],
+		[AC_MSG_ERROR([libubus not found. Please install libubus development package or compile without ubus support.])])
+
+	AC_DEFINE([HAVE_UBUS], [1], [Define to 1 if ubus support is enabled])
+])
+
+AM_CONDITIONAL([ENABLE_UBUS], [test "x$enable_ubus" = "xyes"])
+AC_SUBST(LIBUBOX_LIBS)
+AC_SUBST(LIBUBUS_LIBS)
+
 AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_FILES([Makefile])
 

--- a/list.h
+++ b/list.h
@@ -1,12 +1,12 @@
 /**
- * 
+ *
  * I grub it from linux kernel source code and fix it for user space
  * program. Of course, this is a GPL licensed header file.
  *
  * Here is a recipe to cook list.h for user space program
  *
  * 1. copy list.h from linux/include/list.h
- * 2. remove 
+ * 2. remove
  *     - #ifdef __KERNE__ and its #endif
  *     - all #include line
  *     - prefetch() and rcu related functions
@@ -16,6 +16,9 @@
  */
 #ifndef _LINUX_LIST_H
 #define _LINUX_LIST_H
+
+/* If libubox list.h is already included (uses _LINUX_LIST_H_), use that instead */
+#ifndef _LINUX_LIST_H_
 
 /**
  * @name from other kernel headers
@@ -515,5 +518,6 @@ static inline void hlist_add_after(struct hlist_node *n,
 		({ tpos = hlist_entry(pos, typeof(*tpos), member); 1;}); \
 	     pos = n)
 
+#endif /* !_LINUX_LIST_H_ (libubox not included) */
 
-#endif
+#endif /* _LINUX_LIST_H */

--- a/main.c
+++ b/main.c
@@ -44,6 +44,9 @@
 #include "ctl_socket_server.h"
 #include "driver.h"
 #include "bridge_track.h"
+#ifdef HAVE_UBUS
+#include "ubus.h"
+#endif
 
 #define APP_NAME    "mstpd"
 
@@ -180,14 +183,22 @@ int main(int argc, char *argv[])
     TST(signal_init() == 0, -1);
     TST(driver_mstp_init() == 0, -1);
     TST(init_epoll() == 0, -1);
-    TST(ctl_socket_init() == 0, -1);
     TST(packet_sock_init() == 0, -1);
+#ifdef HAVE_UBUS
+    mstpd_ubus_init();
+#else
+    TST(ctl_socket_init() == 0, -1);
+#endif
     TST(netsock_init() == 0, -1);
     TST(init_bridge_ops() == 0, -1);
 
     c = epoll_main_loop(&quit);
     bridge_track_fini();
-    ctl_socket_cleanup();
+#ifdef HAVE_UBUS
+    mstpd_ubus_exit();
+#else
+   ctl_socket_cleanup();
+#endif
     driver_mstp_fini();
 
     return c;

--- a/ubus.c
+++ b/ubus.c
@@ -1,0 +1,291 @@
+/*
+ * ustp - OpenWrt STP/RSTP/MSTP daemon
+ * Copyright (C) 2021 Felix Fietkau <nbd@nbd.name>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2
+ * as published by the Free Software Foundation
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+#include <libubus.h>
+#include <sys/epoll.h>
+#include "bridge_config.h"
+#include "mstp.h"
+#include "bridge_track.h"
+#include "ubus.h"
+#include "epoll_loop.h"
+#include "log.h"
+
+struct blob_buf b;
+static struct ubus_context *ctx = NULL;
+static struct epoll_event_handler ubus_epoll_handler;
+static bool netifd_subscribed = false;
+
+enum bridge_config_attr {
+    BRIDGE_CONFIG_NAME,
+    BRIDGE_CONFIG_PROTO,
+    BRIDGE_CONFIG_FWD_DELAY,
+    BRIDGE_CONFIG_MAX_AGE,
+    BRIDGE_CONFIG_AGEING_TIME,
+    __BRIDGE_CONFIG_MAX
+};
+
+static const struct blobmsg_policy bridge_config_policy[__BRIDGE_CONFIG_MAX] = {
+    [BRIDGE_CONFIG_NAME] = { "name", BLOBMSG_TYPE_STRING },
+    [BRIDGE_CONFIG_PROTO] = { "proto", BLOBMSG_TYPE_STRING },
+    [BRIDGE_CONFIG_FWD_DELAY] = { "forward_delay", BLOBMSG_TYPE_INT32 },
+    [BRIDGE_CONFIG_MAX_AGE] = { "max_age", BLOBMSG_TYPE_INT32 },
+    [BRIDGE_CONFIG_AGEING_TIME] = { "ageing_time", BLOBMSG_TYPE_INT32 },
+};
+
+static bool ubus_set_bridge_config(struct blob_attr *attr)
+{
+    struct blob_attr *tb[__BRIDGE_CONFIG_MAX], *cur;
+    struct bridge_config *cfg;
+    CIST_BridgeConfig *bc;
+
+    blobmsg_parse(bridge_config_policy, __BRIDGE_CONFIG_MAX, tb,
+                  blobmsg_data(attr), blobmsg_len(attr));
+
+    cur = tb[BRIDGE_CONFIG_NAME];
+    if(!cur)
+        return false;
+
+    cfg = bridge_config_get(blobmsg_get_string(cur), true);
+
+    bc = &cfg->config;
+    bc->protocol_version = protoRSTP;
+    bc->set_protocol_version = true;
+
+    if((cur = tb[BRIDGE_CONFIG_PROTO]) != NULL)
+    {
+        const char *proto = blobmsg_get_string(cur);
+
+        if(!strcmp(proto, "mstp"))
+            bc->protocol_version = protoMSTP;
+        else if(!strcmp(proto, "stp"))
+            bc->protocol_version = protoSTP;
+    }
+
+    if((cur = tb[BRIDGE_CONFIG_FWD_DELAY]) != NULL)
+    {
+        bc->bridge_forward_delay = blobmsg_get_u32(cur);
+        bc->set_bridge_forward_delay = true;
+    }
+
+    if((cur = tb[BRIDGE_CONFIG_AGEING_TIME]) != NULL)
+    {
+        bc->bridge_ageing_time = blobmsg_get_u32(cur);
+        bc->set_bridge_ageing_time = true;
+    }
+
+    if((cur = tb[BRIDGE_CONFIG_MAX_AGE]) != NULL)
+    {
+        bc->bridge_max_age = blobmsg_get_u32(cur);
+        bc->set_bridge_max_age = true;
+    }
+
+    return true;
+}
+
+static int ubus_add_bridge(struct ubus_context *ctx, struct ubus_object *obj,
+                           struct ubus_request_data *req, const char *method,
+                           struct blob_attr *msg)
+{
+    struct blob_attr *tb[__BRIDGE_CONFIG_MAX];
+    struct bridge_config *cfg;
+    const char *bridge_name;
+    unsigned int br_idx = 0;
+    if(!ubus_set_bridge_config(msg))
+        return UBUS_STATUS_INVALID_ARGUMENT;
+
+    blobmsg_parse(bridge_config_policy, __BRIDGE_CONFIG_MAX, tb,
+                  blobmsg_data(msg), blobmsg_len(msg));
+
+    bridge_name = blobmsg_get_string(tb[BRIDGE_CONFIG_NAME]);
+    br_idx = if_nametoindex(bridge_name);
+    if(!br_idx)
+        return UBUS_STATUS_NOT_FOUND;
+    cfg = bridge_config_get(bridge_name, false);
+    if(!cfg)
+        return UBUS_STATUS_NOT_FOUND;
+
+    bridge_create(br_idx, &cfg->config);
+
+    return 0;
+}
+
+enum bridge_delete_attr {
+    BRIDGE_DELETE_NAME,
+    __BRIDGE_DELETE_MAX
+};
+
+static const struct blobmsg_policy bridge_delete_policy[__BRIDGE_DELETE_MAX] = {
+    [BRIDGE_DELETE_NAME] = { "name", BLOBMSG_TYPE_STRING },
+};
+
+static int ubus_delete_bridge(struct ubus_context *ctx, struct ubus_object *obj,
+                              struct ubus_request_data *req, const char *method,
+                              struct blob_attr *msg)
+{
+    struct blob_attr *tb[__BRIDGE_DELETE_MAX];
+    const char *bridge_name;
+    unsigned int br_idx = 0;
+
+    blobmsg_parse(bridge_delete_policy, __BRIDGE_DELETE_MAX, tb,
+                  blobmsg_data(msg), blobmsg_len(msg));
+
+    if(!tb[BRIDGE_DELETE_NAME])
+        return UBUS_STATUS_INVALID_ARGUMENT;
+
+    bridge_name = blobmsg_get_string(tb[BRIDGE_DELETE_NAME]);
+    br_idx = if_nametoindex(bridge_name);
+    if(!br_idx)
+        return UBUS_STATUS_NOT_FOUND;
+
+    bridge_delete(br_idx);
+
+    return 0;
+}
+
+static const struct ubus_method mstpd_methods[] = {
+    UBUS_METHOD("add_bridge", ubus_add_bridge, bridge_config_policy),
+    UBUS_METHOD("delete_bridge", ubus_delete_bridge, bridge_delete_policy),
+};
+
+static struct ubus_object_type mstpd_object_type =
+    UBUS_OBJECT_TYPE("mstpd", mstpd_methods);
+
+static struct ubus_object mstpd_object = {
+    .name = "mstpd",
+    .type = &mstpd_object_type,
+    .methods = mstpd_methods,
+    .n_methods = ARRAY_SIZE(mstpd_methods),
+};
+
+static int netifd_device_cb(struct ubus_context *ctx, struct ubus_object *obj,
+                            struct ubus_request_data *req, const char *method,
+                            struct blob_attr *msg)
+{
+    if(strcmp(method, "stp_init") != 0)
+        return 0;
+
+    ubus_set_bridge_config(msg);
+
+    return 0;
+}
+
+static struct ubus_subscriber netifd_sub = {
+    .cb = netifd_device_cb,
+};
+
+static void try_subscribe_netifd(void)
+{
+    uint32_t id;
+
+    if(!ctx || netifd_subscribed)
+        return;
+
+    if(ubus_lookup_id(ctx, "network.device", &id) != 0)
+        return;
+
+    if(ubus_subscribe(ctx, &netifd_sub, id) != 0)
+        return;
+
+    netifd_subscribed = true;
+
+    /* Request initial configuration */
+    blob_buf_init(&b, 0);
+    ubus_invoke(ctx, id, "stp_init", b.head, NULL, NULL, 1000);
+}
+
+static void ubus_epoll_cb(uint32_t events, struct epoll_event_handler *h)
+{
+    if(!ctx)
+        return;
+
+    ubus_handle_event(ctx);
+
+    if(!netifd_subscribed)
+        try_subscribe_netifd();
+}
+
+static bool mstpd_ubus_connect(void)
+{
+    if(ctx)
+        return true;
+
+    ctx = ubus_connect(NULL);
+    if(!ctx)
+    {
+        ERROR("Failed to connect to ubus");
+        return false;
+    }
+
+    if(ubus_add_object(ctx, &mstpd_object) != 0)
+    {
+        ERROR("Failed to add ubus object");
+        ubus_free(ctx);
+        ctx = NULL;
+        return false;
+    }
+
+    if(ubus_register_subscriber(ctx, &netifd_sub) != 0)
+    {
+        ERROR("Failed to register ubus subscriber");
+        ubus_remove_object(ctx, &mstpd_object);
+        ubus_free(ctx);
+        ctx = NULL;
+        return false;
+    }
+
+    ubus_epoll_handler.fd = ctx->sock.fd;
+    ubus_epoll_handler.handler = ubus_epoll_cb;
+    if(add_epoll(&ubus_epoll_handler) != 0)
+    {
+        ERROR("Failed to add ubus fd to epoll");
+        ubus_unregister_subscriber(ctx, &netifd_sub);
+        ubus_remove_object(ctx, &mstpd_object);
+        ubus_free(ctx);
+        ctx = NULL;
+        return false;
+    }
+
+    INFO("Connected to ubus");
+
+    try_subscribe_netifd();
+
+    return true;
+}
+
+void mstpd_ubus_init(void)
+{
+    mstpd_ubus_connect();
+}
+
+void mstpd_ubus_exit(void)
+{
+    uint32_t id;
+
+    if(!ctx)
+        return;
+
+    remove_epoll(&ubus_epoll_handler);
+
+    if(netifd_subscribed)
+        ubus_unregister_subscriber(ctx, &netifd_sub);
+
+    ubus_remove_object(ctx, &mstpd_object);
+
+    /* Notify netifd that we're shutting down */
+    blob_buf_init(&b, 0);
+    if(ubus_lookup_id(ctx, "network.device", &id) == 0)
+        ubus_invoke(ctx, id, "stp_init", b.head, NULL, NULL, 1000);
+
+    ubus_free(ctx);
+    ctx = NULL;
+}

--- a/ubus.h
+++ b/ubus.h
@@ -1,0 +1,20 @@
+/*
+ * ustp - OpenWrt STP/RSTP/MSTP daemon
+ * Copyright (C) 2021 Felix Fietkau <nbd@nbd.name>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2
+ * as published by the Free Software Foundation
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+#ifndef __UBUS_H
+#define __UBUS_H
+
+void mstpd_ubus_init(void);
+void mstpd_ubus_exit(void);
+
+#endif


### PR DESCRIPTION
Add optional ubus (OpenWrt micro bus architecture) support to enable dynamic bridge configuration via ubus IPC.

A few years ago, a fork of **mstpd** named **ustp** was created to be used in **OpenWrt**. This fork got rid of the **mstpctl** configuration tool and instead provided an API over **ubus** to dynamically set (R)STP configuration. This PR is an attempt to port the **ubus** integration from **ustp** back to **mstpd** (albeit with a slightly different API) while still keeping the **mstpctl** tool available. I have been in contact with the original developer of **ustp**, Felix Fietkau, and he gave permission to try and port some of his work. 

Since there are probably many use cases where the **ubus** interface provides no extra value, I have made it into an optional compile-time feature (enabled by the **--enable-ubus** flag). If you compile with this option enabled, an **mstpd** **ubus** object will be registered providing two methods: **add_bridge** and **delete_bridge**. These methods function similar to respectively the **addbridge** and **delbridge** commands from **mstpctl** with the exception that **add_bridge** takes a number of optional arguments (proto, forward_delay, max_age, ageing_time) to (re)configure STP parameters.

I have left the original **ustp** copyright headers in some of the files since I didn't know what to do with them. I can change them if needed.