### PR TITLE
Fix issue with a configuration name of 32 characters

### DIFF
--- a/mstp.c
+++ b/mstp.c
@@ -1629,8 +1629,13 @@ void MSTP_IN_set_mst_config_id(bridge_t *br, __u16 revision, __u8 *name)
         assign(br->MstConfigId.s.revision_level, valueRevision);
         memset(br->MstConfigId.s.configuration_name, 0,
                sizeof(br->MstConfigId.s.configuration_name));
+        /* configuration_name can be non NUL terminated cf 802.1Q-2022 section 13.8
+         * copy everything and ignore GCC warning */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstringop-truncation"
         strncpy((char *)br->MstConfigId.s.configuration_name, (char *)name,
-                sizeof(br->MstConfigId.s.configuration_name) - 1);
+                sizeof(br->MstConfigId.s.configuration_name));
+#pragma GCC diagnostic pop
         br_state_machines_begin(br);
     }
 }


### PR DESCRIPTION
Since version 0.0.9 and commit d27d7e93485d (treewide: allow room for null-char in strncpy() ) the last character of a configuration name of 32 characters is always lost and replaced by a NULL character.
As far as I know the standard does not have this requirement the configuration name in the MSTP frame can be non NULL terminated.