### PR TITLE
reduce required arguments for *_PRTNAME() and *_MSTINAME()

### DIFF
--- a/bridge_ctl.h
+++ b/bridge_ctl.h
@@ -60,18 +60,21 @@ typedef struct
     _br->sysdeps.name, ##_args)
 #define LOG_BRNAME(_br, _fmt, _args...)     LOG("%s " _fmt, \
     _br->sysdeps.name, ##_args)
-#define ERROR_PRTNAME(_br, _prt, _fmt, _args...) ERROR("%s:%s " _fmt, \
-    _br->sysdeps.name, _prt->sysdeps.name, ##_args)
-#define INFO_PRTNAME(_br, _prt, _fmt, _args...)   INFO("%s:%s " _fmt, \
-    _br->sysdeps.name, _prt->sysdeps.name, ##_args)
-#define LOG_PRTNAME(_br, _prt, _fmt, _args...)    LOG("%s:%s " _fmt,  \
-    _br->sysdeps.name, _prt->sysdeps.name, ##_args)
-#define ERROR_MSTINAME(_br,_prt,_ptp,_fmt,_args...) ERROR("%s:%s:%hu " _fmt, \
-    _br->sysdeps.name, _prt->sysdeps.name, __be16_to_cpu(ptp->MSTID), ##_args)
-#define INFO_MSTINAME(_br,_prt,_ptp,_fmt,_args...)  INFO("%s:%s:%hu " _fmt,  \
-    _br->sysdeps.name, _prt->sysdeps.name, __be16_to_cpu(ptp->MSTID), ##_args)
-#define LOG_MSTINAME(_br,_prt,_ptp,_fmt,_args...)    LOG("%s:%s:%hu " _fmt,  \
-    _br->sysdeps.name, _prt->sysdeps.name, __be16_to_cpu(ptp->MSTID), ##_args)
+#define ERROR_PRTNAME(_prt, _fmt, _args...) ERROR("%s:%s " _fmt, \
+    _prt->bridge->sysdeps.name, _prt->sysdeps.name, ##_args)
+#define INFO_PRTNAME(_prt, _fmt, _args...)   INFO("%s:%s " _fmt, \
+    _prt->bridge->sysdeps.name, _prt->sysdeps.name, ##_args)
+#define LOG_PRTNAME(_prt, _fmt, _args...)    LOG("%s:%s " _fmt,  \
+    _prt->bridge->sysdeps.name, _prt->sysdeps.name, ##_args)
+#define ERROR_MSTINAME(_ptp,_fmt,_args...) ERROR("%s:%s:%hu " _fmt, \
+    _ptp->port->bridge->sysdeps.name, _ptp->port->sysdeps.name,     \
+    __be16_to_cpu(ptp->MSTID), ##_args)
+#define INFO_MSTINAME(_ptp,_fmt,_args...)  INFO("%s:%s:%hu " _fmt,  \
+    _ptp->port->bridge->sysdeps.name, _ptp->port->sysdeps.name,     \
+    __be16_to_cpu(ptp->MSTID), ##_args)
+#define LOG_MSTINAME(_ptp,_fmt,_args...)    LOG("%s:%s:%hu " _fmt,  \
+    _ptp->port->bridge->sysdeps.name, _ptp->port->sysdeps.name,     \
+    __be16_to_cpu(ptp->MSTID), ##_args)
 #define SMLOG_MSTINAME(_ptp, _fmt, _args...)                         \
     PRINT(LOG_LEVEL_STATE_MACHINE_TRANSITION, "%s: %s:%s:%hu " _fmt, \
           __PRETTY_FUNCTION__, _ptp->port->bridge->sysdeps.name,     \

--- a/bridge_track.c
+++ b/bridge_track.c
@@ -484,7 +484,6 @@ void MSTP_OUT_set_state(per_tree_port_t *ptp, int new_state)
 {
     char * state_name;
     port_t *prt = ptp->port;
-    bridge_t *br = prt->bridge;
 
     if(ptp->state == new_state)
         return;
@@ -511,13 +510,13 @@ void MSTP_OUT_set_state(per_tree_port_t *ptp, int new_state)
             state_name = "disabled";
             break;
     }
-    INFO_MSTINAME(br, prt, ptp, "entering %s state", state_name);
+    INFO_MSTINAME(ptp, "entering %s state", state_name);
 
     /* Translate new CIST state to the kernel bridge code */
     if(0 == ptp->MSTID)
     { /* CIST */
         if(0 > br_set_state(&rth_state, prt->sysdeps.if_index, ptp->state))
-            ERROR_PRTNAME(br, prt, "Couldn't set kernel bridge state %s",
+            ERROR_PRTNAME(prt, "Couldn't set kernel bridge state %s",
                           state_name);
     }
 }
@@ -531,17 +530,16 @@ void MSTP_OUT_set_state(per_tree_port_t *ptp, int new_state)
 void MSTP_OUT_flush_all_fids(per_tree_port_t * ptp)
 {
     port_t *prt = ptp->port;
-    bridge_t *br = prt->bridge;
 
     /* Translate CIST flushing to the kernel bridge code */
     if(0 == ptp->MSTID)
     { /* CIST */
         if(0 > br_flush_port(prt->sysdeps.name))
-            ERROR_PRTNAME(br, prt,
+            ERROR_PRTNAME(prt,
                           "Couldn't flush kernel bridge forwarding database");
     }
     /* Completion signal MSTP_IN_all_fids_flushed will be called by driver */
-    INFO_MSTINAME(br, prt, ptp, "Flushing forwarding database");
+    INFO_MSTINAME(ptp, "Flushing forwarding database");
     driver_flush_all_fids(ptp);
 }
 
@@ -551,7 +549,7 @@ void MSTP_OUT_set_ageing_time(port_t *prt, unsigned int ageingTime)
     bridge_t *br = prt->bridge;
 
     actual_ageing_time = driver_set_ageing_time(prt, ageingTime);
-    INFO_PRTNAME(br, prt, "Setting new ageing time to %u", actual_ageing_time);
+    INFO_PRTNAME(prt, "Setting new ageing time to %u", actual_ageing_time);
 
     /*
      * Translate new ageing time to the kernel bridge code.
@@ -565,7 +563,6 @@ void MSTP_OUT_set_ageing_time(port_t *prt, unsigned int ageingTime)
 void MSTP_OUT_tx_bpdu(port_t *prt, bpdu_t * bpdu, int size)
 {
     char *bpdu_type, *tcflag;
-    bridge_t *br = prt->bridge;
 
     switch(bpdu->protocolVersion)
     {
@@ -596,7 +593,7 @@ void MSTP_OUT_tx_bpdu(port_t *prt, bpdu_t * bpdu, int size)
     if((protoSTP == bpdu->protocolVersion) && (bpduTypeTCN == bpdu->bpduType))
     {
         ++(prt->num_tx_tcn);
-        LOG_PRTNAME(br, prt, "sending %s BPDU", bpdu_type);
+        LOG_PRTNAME(prt, "sending %s BPDU", bpdu_type);
     }
     else
     {
@@ -606,7 +603,7 @@ void MSTP_OUT_tx_bpdu(port_t *prt, bpdu_t * bpdu, int size)
             ++(prt->num_tx_tcn);
             tcflag = ", tcFlag";
         }
-        LOG_PRTNAME(br, prt, "sending %s BPDU%s", bpdu_type, tcflag);
+        LOG_PRTNAME(prt, "sending %s BPDU%s", bpdu_type, tcflag);
     }
 
     struct llc_header h;
@@ -628,7 +625,7 @@ void MSTP_OUT_tx_bpdu(port_t *prt, bpdu_t * bpdu, int size)
 void MSTP_OUT_shutdown_port(port_t *prt)
 {
     if(0 > if_shutdown(prt->sysdeps.name))
-        ERROR_PRTNAME(prt->bridge, prt, "Couldn't shutdown port");
+        ERROR_PRTNAME(prt, "Couldn't shutdown port");
 }
 
 /* User interface commands */
@@ -680,7 +677,7 @@ void MSTP_OUT_shutdown_port(port_t *prt)
         }                                                                \
     if(!found)                                                           \
     {                                                                    \
-        ERROR_PRTNAME(br, prt, "Couldn't find MSTI with ID %hu", mstid); \
+        ERROR_PRTNAME(prt, "Couldn't find MSTI with ID %hu", mstid);     \
         return -1;                                                       \
     }
 

--- a/mstp.c
+++ b/mstp.c
@@ -208,7 +208,7 @@ static per_tree_port_t * create_ptp(tree_t *tree, port_t *prt)
     per_tree_port_t *ptp = calloc(1, sizeof(*ptp));
     if(!ptp)
     {
-        ERROR_PRTNAME(prt->bridge, prt, "Out of memory");
+        ERROR_PRTNAME(prt, "Out of memory");
         return NULL;
     }
     ptp->port = prt;
@@ -586,7 +586,7 @@ void MSTP_IN_rx_bpdu(port_t *prt, bpdu_t *bpdu, int size)
     if(prt->BpduGuardPort)
     {
         prt->BpduGuardError = true;
-        ERROR_PRTNAME(br, prt,
+        ERROR_PRTNAME(prt,
                       "Received BPDU on BPDU Guarded Port - Port Down");
         MSTP_OUT_shutdown_port(prt);
         return;
@@ -594,7 +594,7 @@ void MSTP_IN_rx_bpdu(port_t *prt, bpdu_t *bpdu, int size)
 
     if(prt->bpduFilterPort)
     {
-        LOG_PRTNAME(br, prt,
+        LOG_PRTNAME(prt,
                    "Received BPDU on BPDU Filtered Port - discarded");
         ++(prt->num_rx_bpdu_filtered);
         return;
@@ -602,13 +602,13 @@ void MSTP_IN_rx_bpdu(port_t *prt, bpdu_t *bpdu, int size)
 
     if(!br->bridgeEnabled)
     {
-        INFO_PRTNAME(br, prt, "Received BPDU while bridge is disabled");
+        INFO_PRTNAME(prt, "Received BPDU while bridge is disabled");
         return;
     }
 
     if(prt->rcvdBpdu)
     {
-        ERROR_PRTNAME(br, prt, "Port hasn't processed previous BPDU");
+        ERROR_PRTNAME(prt, "Port hasn't processed previous BPDU");
         return;
     }
 
@@ -616,7 +616,7 @@ void MSTP_IN_rx_bpdu(port_t *prt, bpdu_t *bpdu, int size)
     if((TCN_BPDU_SIZE > size) || (0 != bpdu->protocolIdentifier))
     {
 bpdu_validation_failed:
-        INFO_PRTNAME(br, prt, "BPDU validation failed");
+        INFO_PRTNAME(prt, "BPDU validation failed");
         return;
     }
     switch(bpdu->bpduType)
@@ -625,7 +625,7 @@ bpdu_validation_failed:
             /* 14.4.b) */
             /* Valid TCN BPDU */
             bpdu->protocolVersion = protoSTP;
-            LOG_PRTNAME(br, prt, "received TCN BPDU");
+            LOG_PRTNAME(prt, "received TCN BPDU");
             break;
         case bpduTypeConfig:
             /* 14.4.a) */
@@ -633,7 +633,7 @@ bpdu_validation_failed:
                 goto bpdu_validation_failed;
             /* Valid Config BPDU */
             bpdu->protocolVersion = protoSTP;
-            LOG_PRTNAME(br, prt, "received Config BPDU%s",
+            LOG_PRTNAME(prt, "received Config BPDU%s",
                         (bpdu->flags & (1 << offsetTc)) ? ", tcFlag" : ""
                        );
             break;
@@ -644,7 +644,7 @@ bpdu_validation_failed:
                     goto bpdu_validation_failed;
                 /* Valid RST BPDU */
                 /* bpdu->protocolVersion = protoRSTP; */
-                LOG_PRTNAME(br, prt, "received RST BPDU%s",
+                LOG_PRTNAME(prt, "received RST BPDU%s",
                             (bpdu->flags & (1 << offsetTc)) ? ", tcFlag" : ""
                            );
                 break;
@@ -669,7 +669,7 @@ bpdu_validation_failed:
             { /* 14.4.d) */
                 /* Valid RST BPDU */
                 bpdu->protocolVersion = protoRSTP;
-                LOG_PRTNAME(br, prt, "received RST BPDU");
+                LOG_PRTNAME(prt, "received RST BPDU");
                 break;
             }
             /* 14.4.e) */
@@ -677,7 +677,7 @@ bpdu_validation_failed:
             bpdu->protocolVersion = protoMSTP;
             prt->rcvdBpduNumOfMstis = mstis_size
                                       / sizeof(msti_configuration_message_t);
-            LOG_PRTNAME(br, prt, "received MST BPDU%s with %d MSTIs",
+            LOG_PRTNAME(prt, "received MST BPDU%s with %d MSTIs",
                         (bpdu->flags & (1 << offsetTc)) ? ", tcFlag" : "",
                         prt->rcvdBpduNumOfMstis
                        );
@@ -703,7 +703,7 @@ bpdu_validation_failed:
     if(prt->BaInconsistent)
     {
         prt->BaInconsistent = false;
-        INFO_PRTNAME(br, prt, "Clear Bridge assurance inconsistency");
+        INFO_PRTNAME(prt, "Clear Bridge assurance inconsistency");
     }
     updtbrAssuRcvdInfoWhile(prt);
 
@@ -1068,7 +1068,6 @@ int MSTP_IN_set_cist_port_config(port_t *prt, CIST_PortConfig *cfg)
     __u32 new_ExternalPathCost;
     bool new_p2p;
     per_tree_port_t *cist;
-    bridge_t *br = prt->bridge;
 
     /* Firstly, validation */
     if(cfg->set_admin_p2p)
@@ -1088,7 +1087,7 @@ int MSTP_IN_set_cist_port_config(port_t *prt, CIST_PortConfig *cfg)
     {
         if(MAX_PATH_COST < cfg->admin_external_port_path_cost)
         {
-            ERROR_PRTNAME(br, prt,
+            ERROR_PRTNAME(prt,
                           "Port Path Cost must be between 0 and 200000000");
             return -1;
         }
@@ -1179,7 +1178,7 @@ int MSTP_IN_set_cist_port_config(port_t *prt, CIST_PortConfig *cfg)
         if(prt->BpduGuardPort != cfg->bpdu_guard_port)
         {
             prt->BpduGuardPort = cfg->bpdu_guard_port;
-            INFO_PRTNAME(br, prt,"BpduGuardPort new=%d", prt->BpduGuardPort);
+            INFO_PRTNAME(prt,"BpduGuardPort new=%d", prt->BpduGuardPort);
         }
     }
 
@@ -1188,14 +1187,14 @@ int MSTP_IN_set_cist_port_config(port_t *prt, CIST_PortConfig *cfg)
         if(prt->NetworkPort != cfg->network_port)
         {
             prt->NetworkPort = cfg->network_port;
-            INFO_PRTNAME(br, prt, "NetworkPort new=%d", prt->NetworkPort);
+            INFO_PRTNAME(prt, "NetworkPort new=%d", prt->NetworkPort);
             /* When Network port config is removed and bridge assurance
              * inconsistency is set, clear the inconsistency.
              */
             if(!prt->NetworkPort && prt->BaInconsistent)
             {
                 prt->BaInconsistent = false;
-                INFO_PRTNAME(br, prt, "Clear Bridge assurance inconsistency");
+                INFO_PRTNAME(prt, "Clear Bridge assurance inconsistency");
             }
             changed = true;
         }
@@ -1206,7 +1205,7 @@ int MSTP_IN_set_cist_port_config(port_t *prt, CIST_PortConfig *cfg)
         if(prt->dontTxmtBpdu != cfg->dont_txmt)
         {
             prt->dontTxmtBpdu = cfg->dont_txmt;
-            INFO_PRTNAME(br, prt, "donttxmt new=%d", prt->dontTxmtBpdu);
+            INFO_PRTNAME(prt, "donttxmt new=%d", prt->dontTxmtBpdu);
         }
     }
 
@@ -1216,7 +1215,7 @@ int MSTP_IN_set_cist_port_config(port_t *prt, CIST_PortConfig *cfg)
         {
             prt->bpduFilterPort = cfg->bpdu_filter_port;
             prt->num_rx_bpdu_filtered = 0;
-            INFO_PRTNAME(br, prt,"bpduFilterPort new=%d", prt->bpduFilterPort);
+            INFO_PRTNAME(prt,"bpduFilterPort new=%d", prt->bpduFilterPort);
         }
     }
 
@@ -1239,7 +1238,7 @@ int MSTP_IN_set_msti_port_config(per_tree_port_t *ptp, MSTI_PortConfig *cfg)
     {
         if(15 < cfg->port_priority)
         {
-            ERROR_MSTINAME(br, prt, ptp,
+            ERROR_MSTINAME(ptp,
                            "Port Priority must be between 0 and 15");
             return -1;
         }
@@ -1249,7 +1248,7 @@ int MSTP_IN_set_msti_port_config(per_tree_port_t *ptp, MSTI_PortConfig *cfg)
     {
         if (MAX_PATH_COST < cfg->admin_internal_port_path_cost)
         {
-            ERROR_MSTINAME(br, prt, ptp,
+            ERROR_MSTINAME(ptp,
                            "Port Path Cost must be between 0 and 200000000");
             return -1;
         }
@@ -2405,7 +2404,7 @@ static inline __u8 message_role_from_port_role(per_tree_port_t *ptp)
         case roleMaster:
             return encodedRoleMaster;
         default:
-            ERROR_PRTNAME(ptp->port->bridge, ptp->port,
+            ERROR_PRTNAME(ptp->port,
                           "Attempt to send from port with Disabled role");
             return encodedRoleAlternateBackup;
     }
@@ -5069,7 +5068,7 @@ static bool __br_state_machines_run(bridge_t *br, bool dry_run)
             if(dry_run) /* state change */
                 return true;
             prt->BaInconsistent = true;
-            ERROR_PRTNAME(prt->bridge, prt, "Bridge assurance inconsistent");
+            ERROR_PRTNAME(prt, "Bridge assurance inconsistent");
         }
     }
 


### PR DESCRIPTION
Directly take the the bridge from the passed port argument in `*_PRTNAME()`, and take the bridge and port from the per_tree_port in `_MSTINAME()`.

This simplifies logging since we only need to pass one object, not multiple.