### PR TITLE
utils: fix bash completion to use ip instead of brctl

### DIFF
--- a/utils/bash_completion
+++ b/utils/bash_completion
@@ -24,8 +24,8 @@ _mstpctl()
                 debuglevel|showall)
                     ;;
                 *)
-                    COMPREPLY=( $( compgen -W "$( brctl show | \
-                        grep 'yes\|no' | awk '{print $1}')" -- "$cur" ) )
+                    COMPREPLY=( $( compgen -W "$( ip -br link show type bridge | \
+                        awk '{print $1}')" -- "$cur" ) )
             esac
             ;;
         3)


### PR DESCRIPTION
I'm packaging mstpd for Debian as part of the Debian Networking team. While working on that, I've noticed that using `brctl` in the bash completion script causes a `command not found` error when completing bridge names on systems without `bridge-utils` installed. As the program already depends on `iproute2` itself (required by bridge-stp at runtime), I've decided to replace it with `ip -br` call to avoid adding a new runtime dependency