### PR TITLE
Add bridge-stp.8, mstp_restart.8, and mstpd.8 man pages

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -57,7 +57,7 @@ utilsexec_SCRIPTS = utils/ifupdown.sh utils/mstp_config_bridge
 dist_utilsexec_DATA = utils/mstpctl-utils-functions.sh
 sbin_SCRIPTS = bridge-stp
 dist_sysconf_DATA = bridge-stp.conf
-dist_man_MANS = utils/mstpctl.8 utils/mstpctl-utils-interfaces.5
+dist_man_MANS = utils/bridge-stp.8 utils/mstpctl.8 utils/mstpctl-utils-interfaces.5
 
 AM_DISTCHECK_CONFIGURE_FLAGS = --exec_prefix=$$dc_install_base \
 	--libexecdir=$$dc_install_base/lib \

--- a/Makefile.am
+++ b/Makefile.am
@@ -57,7 +57,7 @@ utilsexec_SCRIPTS = utils/ifupdown.sh utils/mstp_config_bridge
 dist_utilsexec_DATA = utils/mstpctl-utils-functions.sh
 sbin_SCRIPTS = bridge-stp
 dist_sysconf_DATA = bridge-stp.conf
-dist_man_MANS = utils/bridge-stp.8 utils/mstpctl.8 utils/mstpctl-utils-interfaces.5
+dist_man_MANS = utils/bridge-stp.8 utils/mstp_restart.8 utils/mstpctl-utils-interfaces.5 utils/mstpctl.8
 
 AM_DISTCHECK_CONFIGURE_FLAGS = --exec_prefix=$$dc_install_base \
 	--libexecdir=$$dc_install_base/lib \

--- a/Makefile.am
+++ b/Makefile.am
@@ -57,7 +57,7 @@ utilsexec_SCRIPTS = utils/ifupdown.sh utils/mstp_config_bridge
 dist_utilsexec_DATA = utils/mstpctl-utils-functions.sh
 sbin_SCRIPTS = bridge-stp
 dist_sysconf_DATA = bridge-stp.conf
-dist_man_MANS = utils/bridge-stp.8 utils/mstp_restart.8 utils/mstpctl-utils-interfaces.5 utils/mstpctl.8
+dist_man_MANS = utils/bridge-stp.8 utils/mstp_restart.8 utils/mstpctl-utils-interfaces.5 utils/mstpctl.8 utils/mstpd.8
 
 AM_DISTCHECK_CONFIGURE_FLAGS = --exec_prefix=$$dc_install_base \
 	--libexecdir=$$dc_install_base/lib \

--- a/mstpd.spec
+++ b/mstpd.spec
@@ -131,6 +131,7 @@ END
 %doc %{_mandir}/man5/mstpctl-utils-interfaces.5.gz
 %doc %{_mandir}/man8/mstp_restart.8
 %doc %{_mandir}/man8/mstpctl.8.gz
+%doc %{_mandir}/man8/mstpd.8.gz
 %doc %{_docdir}/mstpd/README.VLANs
 %doc %{_docdir}/mstpd/README
 %license %{_docdir}/mstpd/LICENSE

--- a/mstpd.spec
+++ b/mstpd.spec
@@ -129,6 +129,7 @@ END
 %{_libexecdir}/mstpctl-utils/mstpctl-utils-functions.sh
 %doc %{_mandir}/man5/bridge-stp.8
 %doc %{_mandir}/man5/mstpctl-utils-interfaces.5.gz
+%doc %{_mandir}/man8/mstp_restart.8
 %doc %{_mandir}/man8/mstpctl.8.gz
 %doc %{_docdir}/mstpd/README.VLANs
 %doc %{_docdir}/mstpd/README

--- a/mstpd.spec
+++ b/mstpd.spec
@@ -127,8 +127,9 @@ END
 %{_libexecdir}/mstpctl-utils/ifquery
 %{_libexecdir}/mstpctl-utils/ifupdown.sh
 %{_libexecdir}/mstpctl-utils/mstpctl-utils-functions.sh
-%doc %{_mandir}/man8/mstpctl.8.gz
+%doc %{_mandir}/man5/bridge-stp.8
 %doc %{_mandir}/man5/mstpctl-utils-interfaces.5.gz
+%doc %{_mandir}/man8/mstpctl.8.gz
 %doc %{_docdir}/mstpd/README.VLANs
 %doc %{_docdir}/mstpd/README
 %license %{_docdir}/mstpd/LICENSE

--- a/utils/bridge-stp.8
+++ b/utils/bridge-stp.8
@@ -1,0 +1,239 @@
+.Dd April 28, 2026
+.Dt BRIDGE-STP 8
+.Os
+.Sh NAME
+.Nm bridge-stp
+.Nd kernel helper script that drives mstpd for Linux bridges
+.Sh SYNOPSIS
+.Nm
+.Ar bridge
+.Cm start | stop
+.Nm
+.Cm restart | restart_config
+.Sh DESCRIPTION
+.Nm
+is the kernel STP helper script for
+.Xr mstpd 8 .
+The Linux kernel invokes
+.Pa /sbin/bridge-stp
+.Ar bridge Cm start
+when STP is enabled on a bridge (via
+.Ic brctl stp Ar bridge Cm on
+or
+.Ic ip link set Ar bridge Ic type bridge stp_state 1 ) ,
+and
+.Pa /sbin/bridge-stp
+.Ar bridge Cm stop
+when STP is disabled.
+On most distributions
+.Pa /sbin
+is a symbolic link to
+.Pa /usr/sbin ,
+so the kernel resolves
+.Pa /sbin/bridge-stp
+to the script installed under
+.Pa /usr/sbin .
+If the script exits
+.Cm 0 ,
+the kernel switches the bridge into
+.Em user_stp
+mode and lets
+.Xr mstpd 8
+drive port states; if it exits non-zero, the kernel falls back to its
+built-in STP implementation.
+.Pp
+On
+.Cm start ,
+.Nm
+verifies that the bridge is listed in
+.Va MSTP_BRIDGES ,
+spawns
+.Xr mstpd 8
+if it is not already running, and asynchronously calls
+.Ic mstpctl addbridge Ar bridge .
+On
+.Cm stop ,
+it removes the bridge from the daemon and terminates
+.Xr mstpd 8
+if no other bridges are still using it.
+.Pp
+.Nm
+must not be invoked directly with the
+.Cm start
+or
+.Cm stop
+arguments
+.Pq the kernel does that ;
+calling them by hand can deadlock the bridge code, because this script
+is forbidden from making bridge configuration changes
+.Pq via Ic brctl , Ic ifconfig , Ic ip , Pa /sys/...
+on the kernel-driven code paths.
+.Pp
+The
+.Cm restart
+and
+.Cm restart_config
+forms are intended for direct use by the administrator and are also
+exposed under shorter names:
+.Bl -tag -width Ds -compact
+.It Xr mstp_restart 8
+equivalent to
+.Nm Cm restart .
+.It Pa /usr/lib/mstpctl-utils/mstpctl_restart_config
+equivalent to
+.Nm Cm restart_config .
+.El
+.Sh COMMANDS
+.Bl -tag -width Ds
+.It Ar bridge Cm start
+Called by the kernel when user-space STP is enabled on
+.Ar bridge .
+Starts
+.Xr mstpd 8
+if necessary and attaches
+.Ar bridge
+to it.
+.It Ar bridge Cm stop
+Called by the kernel when user-space STP is disabled on
+.Ar bridge .
+Detaches
+.Ar bridge
+from
+.Xr mstpd 8
+and stops the daemon if it is no longer needed.
+.It Cm restart
+Stop
+.Xr mstpd 8
+if it is running, start a fresh instance, then re-add and reconfigure
+every bridge that is currently in user_stp mode and listed in
+.Va MSTP_BRIDGES .
+.It Cm restart_config
+Re-add and reconfigure every bridge that is currently in user_stp mode
+and listed in
+.Va MSTP_BRIDGES ,
+without restarting
+.Xr mstpd 8 .
+Use after editing per-bridge configuration.
+.El
+.Sh CONFIGURATION
+.Nm
+sources
+.Pa /etc/bridge-stp.conf
+on every invocation.
+The following shell variables are recognised:
+.Bl -tag -width Ds
+.It Va MANAGE_MSTPD
+.Cm y
+.Pq the default
+to let
+.Nm
+start and stop
+.Xr mstpd 8
+on demand;
+.Cm n
+to require that
+.Xr mstpd 8
+already be running.
+.It Va MSTPD_ARGS
+Extra arguments passed to
+.Xr mstpd 8
+when it is started, e.g.
+.Cm "-v 2" .
+.It Va MSTP_BRIDGES
+Space-separated list of bridges for which MSTP should replace the
+kernel's built-in STP.
+If empty
+.Pq the default ,
+every bridge is eligible.
+.It Va LOGGER
+Command used to log error messages.
+Default:
+.Ic logger -t bridge-stp -s .
+Set to the empty string to log only to standard error.
+.It Va config_cmd
+Per-bridge configuration command invoked by
+.Cm restart
+and
+.Cm restart_config
+as
+.Ic $config_cmd Ar bridge .
+Defaults to
+.Pa /usr/lib/mstpctl-utils/mstp_config_bridge .
+.El
+.Sh FILES
+.Bl -tag -width Ds
+.It Pa /usr/sbin/bridge-stp
+The script itself (exact path depends on
+.Cm --sbindir
+passed to
+.Ic configure ) .
+The kernel invokes it as
+.Pa /sbin/bridge-stp ,
+which on most distributions resolves to this path via the
+.Pa /sbin No \(-> Pa /usr/sbin
+compatibility symlink.
+.It Pa /etc/bridge-stp.conf
+Configuration file.
+.It Pa /sys/class/net/ Ns Ar bridge Ns Pa /bridge/stp_state
+Per-bridge STP state used to decide whether a bridge is currently in
+user_stp mode
+.Pq value Cm 2 .
+.It Pa /var/run/mstpd.pid
+PID file written by
+.Xr mstpd 8 .
+.El
+.Sh EXIT STATUS
+.Bl -tag -width Ds -compact
+.It Cm 0
+Success.
+.It Cm 1
+Bad usage, missing root privileges, or
+.Ar bridge
+is not a bridge.
+.It Cm 2
+.Xr mstpctl 8
+or
+.Xr mstpd 8
+binaries are missing or not executable.
+.It Cm 3
+.Xr mstpd 8
+or
+.Xr mstpctl 8
+failed.
+.It Cm 10
+.Ar bridge
+is not listed in
+.Va MSTP_BRIDGES
+and was therefore ignored
+.Pq returned only on Cm start .
+.El
+.Sh EXAMPLES
+Hand a specific bridge over to
+.Xr mstpd 8 :
+.Dl # ip link set br0 type bridge stp_state 1
+.Pp
+Reload per-bridge configuration without restarting the daemon:
+.Dl # bridge-stp restart_config
+.Pp
+Restart
+.Xr mstpd 8
+and reconfigure every bridge using it:
+.Dl # mstp_restart
+.Sh SEE ALSO
+.Xr mstpctl-utils-interfaces 5 ,
+.Xr brctl 8 ,
+.Xr ip 8 ,
+.Xr mstp_restart 8 ,
+.Xr mstpctl 8 ,
+.Xr mstpd 8
+.Sh AUTHORS
+.An -nosplit
+.Nm
+ships as part of
+.Xr mstpd 8 ,
+written by
+.An Vitalii Demianets Aq Mt dvitasgs@gmail.com
+and others.
+.Pp
+This manual page was written by
+.An Nadzeya Hutsko Aq Mt nadzya.info@gmail.com

--- a/utils/mstp_restart.8
+++ b/utils/mstp_restart.8
@@ -1,0 +1,84 @@
+.Dd April 28, 2026
+.Dt MSTP_RESTART 8
+.Os
+.Sh NAME
+.Nm mstp_restart
+.Nd restart mstpd and reconfigure all attached bridges
+.Sh SYNOPSIS
+.Nm
+.Sh DESCRIPTION
+.Nm
+is a convenience wrapper around
+.Xr bridge-stp 8 .
+It is installed as a symbolic link to
+.Pa /usr/sbin/bridge-stp ;
+when invoked under this name, the helper script takes the
+.Cm restart
+action.
+.Pp
+Calling
+.Nm
+is equivalent to running:
+.Dl # bridge-stp restart
+.Pp
+The script:
+.Bl -bullet -compact
+.It
+sends
+.Dv SIGTERM
+to the running
+.Xr mstpd 8 ,
+if any;
+.It
+starts a fresh
+.Xr mstpd 8
+with the arguments listed in
+.Va MSTPD_ARGS
+in
+.Pa /etc/bridge-stp.conf ;
+.It
+re-adds every bridge that is currently in user_stp mode and is listed
+in
+.Va MSTP_BRIDGES ,
+running the per-bridge configuration command
+.Pq usually Pa /usr/lib/mstpctl-utils/mstp_config_bridge
+on each.
+.El
+.Pp
+Bridges that are not in user_stp mode
+.Pq Pa /sys/class/net/ Ns Ar bridge Ns Pa /bridge/stp_state No != Cm 2
+are skipped, with a hint on how to re-enable user-space STP for them.
+.Pp
+.Nm
+must be run as root.
+To reconfigure existing bridges without restarting the daemon, use
+.Ic bridge-stp restart_config
+instead.
+.Sh FILES
+.Bl -tag -width Ds
+.It Pa /usr/sbin/mstp_restart
+Symbolic link to
+.Pa /usr/sbin/bridge-stp .
+.It Pa /etc/bridge-stp.conf
+Configuration file read by the underlying
+.Xr bridge-stp 8
+script.
+.El
+.Sh EXIT STATUS
+Inherits the exit status of
+.Xr bridge-stp 8 .
+.Sh SEE ALSO
+.Xr bridge-stp 8 ,
+.Xr mstpctl 8 ,
+.Xr mstpd 8
+.Sh AUTHORS
+.An -nosplit
+.Nm
+ships as part of
+.Xr mstpd 8 ,
+written by
+.An Vitalii Demianets Aq Mt dvitasgs@gmail.com
+and others.
+.Pp
+This manual page was written by
+.An Nadzeya Hutsko Aq Mt nadzya.info@gmail.com

--- a/utils/mstpd.8
+++ b/utils/mstpd.8
@@ -1,0 +1,158 @@
+.Dd April 28, 2026
+.Dt MSTPD 8
+.Os
+.Sh NAME
+.Nm mstpd
+.Nd Multiple Spanning Tree Protocol daemon
+.Sh SYNOPSIS
+.Nm
+.Op Fl d
+.Op Fl s
+.Op Fl v Ar level
+.Nm
+.Fl V
+.Sh DESCRIPTION
+.Nm
+is a user-space daemon that implements the IEEE 802.1D-2004 STP, the IEEE
+802.1D-2004 RSTP and the IEEE 802.1Q-2005 MSTP variants of the Spanning
+Tree Protocol for Linux bridges.
+It replaces the in-kernel STP implementation by running the bridge in
+.Em user_stp
+mode and translates the resulting CIST port states back to the kernel
+bridge.
+.Pp
+.Nm
+relies on the
+.Xr bridge-stp 8
+helper script, which the kernel invokes whenever STP is enabled or
+disabled on a bridge (via
+.Ic brctl stp Ar bridge Ic on No / Ic off
+or
+.Ic ip link set Ar bridge Ic type bridge stp_state Ar 0|1 ) ,
+to start, stop and attach bridges to the running daemon.
+Once started,
+.Nm
+is configured at runtime through
+.Xr mstpctl 8 .
+.Pp
+The MSTP code path is largely untested and is not recommended for
+production use; the STP and RSTP code paths are well exercised and pass
+the IXIA ANVL RSTP test suite (with the exception of looped-back BPDUs).
+.Pp
+By default,
+.Nm
+forks into the background, writes its PID to
+.Pa /var/run/mstpd.pid ,
+and logs through
+.Xr syslog 3
+under the
+.Cm daemon
+facility.
+.Sh OPTIONS
+.Bl -tag -width Ds
+.It Fl d
+Do not daemonize.
+.Nm
+stays in the foreground and logs to standard output instead of
+.Xr syslog 3 ,
+unless
+.Fl s
+is also given.
+Useful for debugging and for running under a service supervisor.
+.It Fl s
+Log to
+.Xr syslog 3
+even when running in the foreground.
+Implied when daemonizing.
+.It Fl v Ar level
+Set the log verbosity.
+.Ar level
+is an integer:
+.Cm 0
+silences all output,
+.Cm 1
+prints errors only,
+.Cm 2
+.Pq the default
+adds informational messages, and
+.Cm 3
+adds debug traces.
+Higher values up to
+.Cm 100
+are accepted but produce no additional detail.
+.It Fl V
+Print the
+.Nm
+version and exit.
+.El
+.Sh SIGNALS
+.Bl -tag -width Ds
+.It Dv SIGTERM , SIGINT , SIGHUP , SIGUSR2
+Shut down cleanly.
+.It Dv SIGUSR1
+Raise the log level to
+.Cm debug
+at runtime.
+.It Dv SIGPIPE
+Ignored.
+.El
+.Sh FILES
+.Bl -tag -width Ds
+.It Pa /var/run/mstpd.pid
+PID file written when running as a daemon.
+.It Pa /etc/bridge-stp.conf
+Configuration file read by
+.Xr bridge-stp 8 ;
+controls whether
+.Nm
+is started automatically and which arguments are passed to it.
+.El
+.Pp
+.Xr mstpctl 8
+talks to the daemon over a Linux abstract Unix-domain socket
+.Pq Dv AF_UNIX No name Li \e0.mstp_server ,
+not over a socket file in the filesystem.
+.Sh EXIT STATUS
+.Nm
+exits
+.Cm 0
+on a clean shutdown and non-zero on a fatal error (failure to daemonize,
+to create the PID file, to open the control socket, or to attach to
+.Xr netlink 7 ) .
+.Sh EXAMPLES
+Run in the foreground with debug logging, for troubleshooting:
+.Dl # mstpd -d -v 4
+.Pp
+Enable user-space STP on a bridge so that the kernel hands control to
+.Nm
+through
+.Xr bridge-stp 8 :
+.Dl # ip link set br0 type bridge stp_state 1
+.Pp
+Inspect the running daemon's view of a bridge:
+.Dl # mstpctl showbridge br0
+.Sh SEE ALSO
+.Xr mstpctl-utils-interfaces 5 ,
+.Xr brctl 8 ,
+.Xr bridge-stp 8 ,
+.Xr ip 8 ,
+.Xr mstp_restart 8 ,
+.Xr mstpctl 8
+.Sh STANDARDS
+.Rs
+.%T IEEE Std 802.1D-2004, Media Access Control (MAC) Bridges
+.Re
+.Rs
+.%T IEEE Std 802.1Q-2005, Virtual Bridged Local Area Networks
+.Re
+.Sh AUTHORS
+.An -nosplit
+.Nm
+was written by
+.An Srinivas Aji Aq Mt Aji_Srinivas@emc.com
+and
+.An Vitalii Demianets Aq Mt dvitasgs@gmail.com ,
+with contributions from many others.
+.Pp
+This manual page was written by
+.An Nadzeya Hutsko Aq Mt nadzya.info@gmail.com


### PR DESCRIPTION
As I was packaging mstpd for Debian, I wrote the man pages for the `bridge-stp`, `mstp_restart`, and `mstpd` binaries. I would appreciate it if you could review them, provide your suggestions or feedback, and, if possible, include these man pages in the code for the next release. This would help reduce the maintenance burden