### PR TITLE
debian: remove debian/ directory

### DIFF
--- a/debian/README.md
+++ b/debian/README.md
@@ -1,4 +1,0 @@
-# Packaging for Debian
-
-The packaging for Debian has been removed from this branch. It is now
-located in the `debian/sid` branch.


### PR DESCRIPTION
The package is maintained on Salsa as a non-native Debian package, so the debian/ directory belongs in the repository there: https://salsa.debian.org/networking-team/mstpd