### PR TITLE
libnetlink: sync with iproute2 v7.0.0

### DIFF
--- a/bridge_track.c
+++ b/bridge_track.c
@@ -461,7 +461,7 @@ static int br_set_state(struct rtnl_handle *rth, unsigned ifindex, __u8 state)
 
     addattr8(&req.n, sizeof(req.buf), IFLA_PROTINFO, state);
 
-    return rtnl_talk(rth, &req.n, 0, 0, NULL, NULL, NULL);
+    return rtnl_talk(rth, &req.n, NULL);
 }
 
 static int br_flush_port(char *ifname)

--- a/brmon.c
+++ b/brmon.c
@@ -58,7 +58,7 @@ static struct epoll_event_handler br_handler;
 
 struct rtnl_handle rth_state;
 
-static int dump_msg(const struct sockaddr_nl *who, struct nlmsghdr *n,
+static int listen_msg(struct rtnl_ctrl_data *data, struct nlmsghdr *n,
                     void *arg)
 {
     struct ifinfomsg *ifi = NLMSG_DATA(n);
@@ -165,10 +165,14 @@ static int dump_msg(const struct sockaddr_nl *who, struct nlmsghdr *n,
 
     return 0;
 }
+static int dump_msg(struct nlmsghdr *n, void *arg)
+{
+    return listen_msg(NULL, n, arg);
+}
 
 static inline void br_ev_handler(uint32_t events, struct epoll_event_handler *h)
 {
-    if(rtnl_listen(&rth, dump_msg, stdout) < 0)
+    if(rtnl_listen(&rth, listen_msg, stdout) < 0)
     {
         ERROR("Error on bridge monitoring socket\n");
     }
@@ -188,13 +192,13 @@ int init_bridge_ops(void)
         return -1;
     }
 
-    if(rtnl_wilddump_request(&rth, PF_BRIDGE, RTM_GETLINK) < 0)
+    if(rtnl_linkdump_req(&rth, PF_BRIDGE) < 0)
     {
         ERROR("Cannot send dump request: %m\n");
         return -1;
     }
 
-    if(rtnl_dump_filter(&rth, dump_msg, stdout, NULL, NULL) < 0)
+    if(rtnl_dump_filter(&rth, dump_msg, stdout) < 0)
     {
         ERROR("Dump terminated\n");
         return -1;

--- a/libnetlink.c
+++ b/libnetlink.c
@@ -1,19 +1,14 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 /*
  * libnetlink.c	RTnetlink service routines.
  *
- *		This program is free software; you can redistribute it and/or
- *		modify it under the terms of the GNU General Public License
- *		as published by the Free Software Foundation; either version
- *		2 of the License, or (at your option) any later version.
- *
  * Authors:	Alexey Kuznetsov, <kuznet@ms2.inr.ac.ru>
- *
  */
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdbool.h>
 #include <unistd.h>
-#include <syslog.h>
 #include <fcntl.h>
 #include <net/if_arp.h>
 #include <sys/socket.h>
@@ -22,131 +17,687 @@
 #include <errno.h>
 #include <time.h>
 #include <sys/uio.h>
+#include <linux/fib_rules.h>
+#include <linux/if_addrlabel.h>
+#include <linux/if_bridge.h>
+#include <linux/nexthop.h>
 
 #include "log.h"
 #include "libnetlink.h"
 
-#ifndef DEFAULT_RTNL_BUFSIZE
-#define DEFAULT_RTNL_BUFSIZE	256 * 1024
+/* mstpd: stubs for rtnl_echo_talk() */
+static inline void new_json_obj(int json) { }
+static inline void delete_json_obj(void) { }
+static inline void open_json_object(const char *str) { }
+static inline void close_json_object(void) { }
+
+#ifndef __aligned
+#define __aligned(x)		__attribute__((aligned(x)))
 #endif
 
-#ifndef RTNL_SND_BUFSIZE
-#define RTNL_SND_BUFSIZE	DEFAULT_RTNL_BUFSIZE
+#ifndef SOL_NETLINK
+#define SOL_NETLINK 270
 #endif
-#ifndef RTNL_RCV_BUFSIZE
-#define RTNL_RCV_BUFSIZE	DEFAULT_RTNL_BUFSIZE
+
+#ifndef MIN
+#define MIN(a, b) ((a) < (b) ? (a) : (b))
 #endif
+
+int rcvbuf = 1024 * 1024;
+
+#ifdef HAVE_LIBMNL
+#include <libmnl/libmnl.h>
+
+static const enum mnl_attr_data_type extack_policy[NLMSGERR_ATTR_MAX + 1] = {
+	[NLMSGERR_ATTR_MSG]	= MNL_TYPE_NUL_STRING,
+	[NLMSGERR_ATTR_OFFS]	= MNL_TYPE_U32,
+};
+
+static int err_attr_cb(const struct nlattr *attr, void *data)
+{
+	const struct nlattr **tb = data;
+	uint16_t type;
+
+	if (mnl_attr_type_valid(attr, NLMSGERR_ATTR_MAX) < 0) {
+		ERROR("Invalid extack attribute");
+		return MNL_CB_ERROR;
+	}
+
+	type = mnl_attr_get_type(attr);
+	if (mnl_attr_validate(attr, extack_policy[type]) < 0) {
+		ERROR("extack attribute %d failed validation",
+			type);
+		return MNL_CB_ERROR;
+	}
+
+	tb[type] = attr;
+	return MNL_CB_OK;
+}
+
+static void print_ext_ack_msg(bool is_err, const char *msg)
+{
+	ERROR("%s: %s%s", is_err ? "Error" : "Warning", msg,
+		msg[strlen(msg) - 1] != '.' ? "." : "");
+}
+
+/* dump netlink extended ack error message */
+int nl_dump_ext_ack(const struct nlmsghdr *nlh, nl_ext_ack_fn_t errfn)
+{
+	struct nlattr *tb[NLMSGERR_ATTR_MAX + 1] = {};
+	const struct nlmsgerr *err = mnl_nlmsg_get_payload(nlh);
+	const struct nlmsghdr *err_nlh = NULL;
+	unsigned int hlen = sizeof(*err);
+	const char *msg = NULL;
+	uint32_t off = 0;
+
+	/* no TLVs, nothing to do here */
+	if (!(nlh->nlmsg_flags & NLM_F_ACK_TLVS))
+		return 0;
+
+	/* if NLM_F_CAPPED is set then the inner err msg was capped */
+	if (!(nlh->nlmsg_flags & NLM_F_CAPPED))
+		hlen += mnl_nlmsg_get_payload_len(&err->msg);
+
+	if (mnl_attr_parse(nlh, hlen, err_attr_cb, tb) != MNL_CB_OK)
+		return 0;
+
+	if (tb[NLMSGERR_ATTR_MSG])
+		msg = mnl_attr_get_str(tb[NLMSGERR_ATTR_MSG]);
+
+	if (tb[NLMSGERR_ATTR_OFFS]) {
+		off = mnl_attr_get_u32(tb[NLMSGERR_ATTR_OFFS]);
+
+		if (off > nlh->nlmsg_len) {
+			ERROR("Invalid offset for NLMSGERR_ATTR_OFFS");
+			off = 0;
+		} else if (!(nlh->nlmsg_flags & NLM_F_CAPPED))
+			err_nlh = &err->msg;
+	}
+
+	if (tb[NLMSGERR_ATTR_MISS_TYPE])
+		ERROR("Missing required attribute type %u",
+			mnl_attr_get_u32(tb[NLMSGERR_ATTR_MISS_TYPE]));
+
+	if (errfn)
+		return errfn(msg, off, err_nlh);
+
+	if (msg && *msg != '\0') {
+		bool is_err = !!err->error;
+
+		print_ext_ack_msg(is_err, msg);
+		return is_err ? 1 : 0;
+	}
+
+	return 0;
+}
+
+int nl_dump_ext_ack_done(const struct nlmsghdr *nlh, unsigned int offset, int error)
+{
+	struct nlattr *tb[NLMSGERR_ATTR_MAX + 1] = {};
+	const char *msg = NULL;
+
+	if (mnl_attr_parse(nlh, offset, err_attr_cb, tb) != MNL_CB_OK)
+		return 0;
+
+	if (tb[NLMSGERR_ATTR_MSG])
+		msg = mnl_attr_get_str(tb[NLMSGERR_ATTR_MSG]);
+
+	if (msg && *msg != '\0') {
+		bool is_err = !!error;
+
+		print_ext_ack_msg(is_err, msg);
+		return is_err ? 1 : 0;
+	}
+
+	return 0;
+}
+#else
+
+/* No extended error ack without libmnl */
+int nl_dump_ext_ack(const struct nlmsghdr *nlh, nl_ext_ack_fn_t errfn)
+{
+	return 0;
+}
+
+int nl_dump_ext_ack_done(const struct nlmsghdr *nlh, unsigned int offset, int error)
+{
+	return 0;
+}
+#endif
+
+/* Older kernels may not support strict dump and filtering */
+void rtnl_set_strict_dump(struct rtnl_handle *rth)
+{
+	int one = 1;
+
+	if (setsockopt(rth->fd, SOL_NETLINK, NETLINK_GET_STRICT_CHK,
+		       &one, sizeof(one)) < 0)
+		return;
+
+	rth->flags |= RTNL_HANDLE_F_STRICT_CHK;
+}
+
+int rtnl_add_nl_group(struct rtnl_handle *rth, unsigned int group)
+{
+	return setsockopt(rth->fd, SOL_NETLINK, NETLINK_ADD_MEMBERSHIP,
+			  &group, sizeof(group));
+}
 
 void rtnl_close(struct rtnl_handle *rth)
 {
-	close(rth->fd);
+	if (rth->fd >= 0) {
+		close(rth->fd);
+		rth->fd = -1;
+	}
 }
 
-int rtnl_open_byproto(struct rtnl_handle *rth, unsigned subscriptions,
+int rtnl_open_byproto(struct rtnl_handle *rth, unsigned int subscriptions,
 		      int protocol)
 {
 	socklen_t addr_len;
-	int sndbuf = RTNL_SND_BUFSIZE;
-	int rcvbuf = RTNL_RCV_BUFSIZE;
+	int sndbuf = 32768;
+	int one = 1;
 
 	memset(rth, 0, sizeof(*rth));
 
-	rth->fd = socket(AF_NETLINK, SOCK_RAW, protocol);
+	rth->proto = protocol;
+	rth->fd = socket(AF_NETLINK, SOCK_RAW | SOCK_CLOEXEC, protocol);
 	if (rth->fd < 0) {
-		ERROR("Cannot open netlink socket");
+		ERROR("Cannot open netlink socket: %m");
 		return -1;
 	}
 
-	if (setsockopt(rth->fd, SOL_SOCKET, SO_SNDBUF, &sndbuf, sizeof(sndbuf))
-	    < 0) {
-		ERROR("SO_SNDBUF");
-		goto err_close;
+	if (setsockopt(rth->fd, SOL_SOCKET, SO_SNDBUF,
+		       &sndbuf, sizeof(sndbuf)) < 0) {
+		ERROR("SO_SNDBUF: %m");
+		goto err;
 	}
 
-	if (setsockopt(rth->fd, SOL_SOCKET, SO_RCVBUF, &rcvbuf, sizeof(rcvbuf))
-	    < 0) {
-		ERROR("SO_RCVBUF");
-		goto err_close;
+	if (setsockopt(rth->fd, SOL_SOCKET, SO_RCVBUF,
+		       &rcvbuf, sizeof(rcvbuf)) < 0) {
+		ERROR("SO_RCVBUF: %m");
+		goto err;
 	}
+
+	/* Older kernels may no support extended ACK reporting */
+	setsockopt(rth->fd, SOL_NETLINK, NETLINK_EXT_ACK,
+		   &one, sizeof(one));
 
 	memset(&rth->local, 0, sizeof(rth->local));
 	rth->local.nl_family = AF_NETLINK;
 	rth->local.nl_groups = subscriptions;
 
-	if (bind(rth->fd, (struct sockaddr *)&rth->local, sizeof(rth->local)) <
-	    0) {
-		ERROR("Cannot bind netlink socket");
-		goto err_close;
+	if (bind(rth->fd, (struct sockaddr *)&rth->local,
+		 sizeof(rth->local)) < 0) {
+		ERROR("Cannot bind netlink socket: %m");
+		goto err;
 	}
 	addr_len = sizeof(rth->local);
-	if (getsockname(rth->fd, (struct sockaddr *)&rth->local, &addr_len) < 0) {
-		ERROR("Cannot getsockname");
-		goto err_close;
+	if (getsockname(rth->fd, (struct sockaddr *)&rth->local,
+			&addr_len) < 0) {
+		ERROR("Cannot getsockname: %m");
+		goto err;
 	}
 	if (addr_len != sizeof(rth->local)) {
-		ERROR("Wrong address length %d\n", addr_len);
-		goto err_close;
+		ERROR("Wrong address length %d", addr_len);
+		goto err;
 	}
 	if (rth->local.nl_family != AF_NETLINK) {
-		ERROR("Wrong address family %d\n",
+		ERROR("Wrong address family %d",
 			rth->local.nl_family);
-		goto err_close;
+		goto err;
 	}
 	rth->seq = time(NULL);
 	return 0;
-
-err_close:
-	close(rth->fd);
+err:
+	rtnl_close(rth);
 	return -1;
 }
 
-int rtnl_open(struct rtnl_handle *rth, unsigned subscriptions)
+int rtnl_open(struct rtnl_handle *rth, unsigned int subscriptions)
 {
 	return rtnl_open_byproto(rth, subscriptions, NETLINK_ROUTE);
 }
 
-int rtnl_wilddump_request(struct rtnl_handle *rth, int family, int type)
+int rtnl_nexthopdump_req(struct rtnl_handle *rth, int family,
+			 req_filter_fn_t filter_fn)
 {
 	struct {
 		struct nlmsghdr nlh;
-		struct rtgenmsg g;
-	} req;
-	struct sockaddr_nl nladdr;
+		struct nhmsg nhm;
+		char buf[128];
+	} req = {
+		.nlh.nlmsg_len = NLMSG_LENGTH(sizeof(struct nhmsg)),
+		.nlh.nlmsg_type = RTM_GETNEXTHOP,
+		.nlh.nlmsg_flags = NLM_F_DUMP | NLM_F_REQUEST,
+		.nlh.nlmsg_seq = rth->dump = ++rth->seq,
+		.nhm.nh_family = family,
+	};
 
-	memset(&nladdr, 0, sizeof(nladdr));
-	nladdr.nl_family = AF_NETLINK;
+	if (filter_fn) {
+		int err;
 
-	memset(&req, 0, sizeof(req));
-	req.nlh.nlmsg_len = sizeof(req);
-	req.nlh.nlmsg_type = type;
-	req.nlh.nlmsg_flags = NLM_F_ROOT | NLM_F_MATCH | NLM_F_REQUEST;
-	req.nlh.nlmsg_pid = 0;
-	req.nlh.nlmsg_seq = rth->dump = ++rth->seq;
-	req.g.rtgen_family = family;
+		err = filter_fn(&req.nlh, sizeof(req));
+		if (err)
+			return err;
+	}
 
-	return sendto(rth->fd, (void *)&req, sizeof(req), 0,
-		      (struct sockaddr *)&nladdr, sizeof(nladdr));
+	return send(rth->fd, &req, sizeof(req), 0);
 }
 
-int rtnl_send(struct rtnl_handle *rth, const char *buf, int len)
+int rtnl_nexthop_bucket_dump_req(struct rtnl_handle *rth, int family,
+				 req_filter_fn_t filter_fn)
 {
-	struct sockaddr_nl nladdr;
+	struct {
+		struct nlmsghdr nlh;
+		struct nhmsg nhm;
+		char buf[128];
+	} req = {
+		.nlh.nlmsg_len = NLMSG_LENGTH(sizeof(struct nhmsg)),
+		.nlh.nlmsg_type = RTM_GETNEXTHOPBUCKET,
+		.nlh.nlmsg_flags = NLM_F_DUMP | NLM_F_REQUEST,
+		.nlh.nlmsg_seq = rth->dump = ++rth->seq,
+		.nhm.nh_family = family,
+	};
 
-	memset(&nladdr, 0, sizeof(nladdr));
-	nladdr.nl_family = AF_NETLINK;
+	if (filter_fn) {
+		int err;
 
-	return sendto(rth->fd, buf, len, 0, (struct sockaddr *)&nladdr,
-		      sizeof(nladdr));
+		err = filter_fn(&req.nlh, sizeof(req));
+		if (err)
+			return err;
+	}
+
+	return send(rth->fd, &req, sizeof(req), 0);
+}
+
+int rtnl_addrdump_req(struct rtnl_handle *rth, int family,
+		      req_filter_fn_t filter_fn)
+{
+	struct {
+		struct nlmsghdr nlh;
+		struct ifaddrmsg ifm;
+		char buf[128];
+	} req = {
+		.nlh.nlmsg_len = NLMSG_LENGTH(sizeof(struct ifaddrmsg)),
+		.nlh.nlmsg_type = RTM_GETADDR,
+		.nlh.nlmsg_flags = NLM_F_DUMP | NLM_F_REQUEST,
+		.nlh.nlmsg_seq = rth->dump = ++rth->seq,
+		.ifm.ifa_family = family,
+	};
+
+	if (filter_fn) {
+		int err;
+
+		err = filter_fn(&req.nlh, sizeof(req));
+		if (err)
+			return err;
+	}
+
+	return send(rth->fd, &req, sizeof(req), 0);
+}
+
+int rtnl_addrlbldump_req(struct rtnl_handle *rth, int family)
+{
+	struct {
+		struct nlmsghdr nlh;
+		struct ifaddrlblmsg ifal;
+	} req = {
+		.nlh.nlmsg_len = NLMSG_LENGTH(sizeof(struct ifaddrlblmsg)),
+		.nlh.nlmsg_type = RTM_GETADDRLABEL,
+		.nlh.nlmsg_flags = NLM_F_DUMP | NLM_F_REQUEST,
+		.nlh.nlmsg_seq = rth->dump = ++rth->seq,
+		.ifal.ifal_family = family,
+	};
+
+	return send(rth->fd, &req, sizeof(req), 0);
+}
+
+int rtnl_routedump_req(struct rtnl_handle *rth, int family,
+		       req_filter_fn_t filter_fn)
+{
+	struct {
+		struct nlmsghdr nlh;
+		struct rtmsg rtm;
+		char buf[128];
+	} req = {
+		.nlh.nlmsg_len = NLMSG_LENGTH(sizeof(struct rtmsg)),
+		.nlh.nlmsg_type = RTM_GETROUTE,
+		.nlh.nlmsg_flags = NLM_F_DUMP | NLM_F_REQUEST,
+		.nlh.nlmsg_seq = rth->dump = ++rth->seq,
+		.rtm.rtm_family = family,
+	};
+
+	if (filter_fn) {
+		int err;
+
+		err = filter_fn(&req.nlh, sizeof(req));
+		if (err)
+			return err;
+	}
+
+	return send(rth->fd, &req, sizeof(req), 0);
+}
+
+int rtnl_ruledump_req(struct rtnl_handle *rth, int family)
+{
+	struct {
+		struct nlmsghdr nlh;
+		struct fib_rule_hdr frh;
+	} req = {
+		.nlh.nlmsg_len = NLMSG_LENGTH(sizeof(struct fib_rule_hdr)),
+		.nlh.nlmsg_type = RTM_GETRULE,
+		.nlh.nlmsg_flags = NLM_F_DUMP | NLM_F_REQUEST,
+		.nlh.nlmsg_seq = rth->dump = ++rth->seq,
+		.frh.family = family
+	};
+
+	return send(rth->fd, &req, sizeof(req), 0);
+}
+
+int rtnl_neighdump_req(struct rtnl_handle *rth, int family,
+		       req_filter_fn_t filter_fn)
+{
+	struct {
+		struct nlmsghdr nlh;
+		struct ndmsg ndm;
+		char buf[256];
+	} req = {
+		.nlh.nlmsg_len = NLMSG_LENGTH(sizeof(struct ndmsg)),
+		.nlh.nlmsg_type = RTM_GETNEIGH,
+		.nlh.nlmsg_flags = NLM_F_DUMP | NLM_F_REQUEST,
+		.nlh.nlmsg_seq = rth->dump = ++rth->seq,
+		.ndm.ndm_family = family,
+	};
+
+	if (filter_fn) {
+		int err;
+
+		err = filter_fn(&req.nlh, sizeof(req));
+		if (err)
+			return err;
+	}
+
+	return send(rth->fd, &req, sizeof(req), 0);
+}
+
+int rtnl_neightbldump_req(struct rtnl_handle *rth, int family)
+{
+	struct {
+		struct nlmsghdr nlh;
+		struct ndtmsg ndtmsg;
+	} req = {
+		.nlh.nlmsg_len = NLMSG_LENGTH(sizeof(struct ndtmsg)),
+		.nlh.nlmsg_type = RTM_GETNEIGHTBL,
+		.nlh.nlmsg_flags = NLM_F_DUMP | NLM_F_REQUEST,
+		.nlh.nlmsg_seq = rth->dump = ++rth->seq,
+		.ndtmsg.ndtm_family = family,
+	};
+
+	return send(rth->fd, &req, sizeof(req), 0);
+}
+
+int rtnl_mdbdump_req(struct rtnl_handle *rth, int family)
+{
+	struct {
+		struct nlmsghdr nlh;
+		struct br_port_msg bpm;
+	} req = {
+		.nlh.nlmsg_len = NLMSG_LENGTH(sizeof(struct br_port_msg)),
+		.nlh.nlmsg_type = RTM_GETMDB,
+		.nlh.nlmsg_flags = NLM_F_DUMP | NLM_F_REQUEST,
+		.nlh.nlmsg_seq = rth->dump = ++rth->seq,
+		.bpm.family = family,
+	};
+
+	return send(rth->fd, &req, sizeof(req), 0);
+}
+
+int rtnl_brvlandump_req(struct rtnl_handle *rth, int family, __u32 dump_flags)
+{
+	struct {
+		struct nlmsghdr nlh;
+		struct br_vlan_msg bvm;
+		char buf[256];
+	} req = {
+		.nlh.nlmsg_len = NLMSG_LENGTH(sizeof(struct br_vlan_msg)),
+		.nlh.nlmsg_type = RTM_GETVLAN,
+		.nlh.nlmsg_flags = NLM_F_DUMP | NLM_F_REQUEST,
+		.nlh.nlmsg_seq = rth->dump = ++rth->seq,
+		.bvm.family = family,
+	};
+
+	addattr32(&req.nlh, sizeof(req), BRIDGE_VLANDB_DUMP_FLAGS, dump_flags);
+
+	return send(rth->fd, &req, sizeof(req), 0);
+}
+
+int rtnl_netconfdump_req(struct rtnl_handle *rth, int family)
+{
+	struct {
+		struct nlmsghdr nlh;
+		struct netconfmsg ncm;
+		char buf[0] __aligned(NLMSG_ALIGNTO);
+	} req = {
+		.nlh.nlmsg_len = NLMSG_LENGTH(NLMSG_ALIGN(sizeof(struct netconfmsg))),
+		.nlh.nlmsg_type = RTM_GETNETCONF,
+		.nlh.nlmsg_flags = NLM_F_DUMP | NLM_F_REQUEST,
+		.nlh.nlmsg_seq = rth->dump = ++rth->seq,
+		.ncm.ncm_family = family,
+	};
+
+	return send(rth->fd, &req, sizeof(req), 0);
+}
+
+int rtnl_nsiddump_req_filter_fn(struct rtnl_handle *rth, int family,
+				req_filter_fn_t filter_fn)
+{
+	struct {
+		struct nlmsghdr nlh;
+		struct rtgenmsg rtm;
+		char buf[1024];
+	} req = {
+		.nlh.nlmsg_len = NLMSG_LENGTH(NLMSG_ALIGN(sizeof(struct rtgenmsg))),
+		.nlh.nlmsg_type = RTM_GETNSID,
+		.nlh.nlmsg_flags = NLM_F_DUMP | NLM_F_REQUEST,
+		.nlh.nlmsg_seq = rth->dump = ++rth->seq,
+		.rtm.rtgen_family = family,
+	};
+	int err;
+
+	if (!filter_fn)
+		return -EINVAL;
+
+	err = filter_fn(&req.nlh, sizeof(req));
+	if (err)
+		return err;
+
+	return send(rth->fd, &req, req.nlh.nlmsg_len, 0);
+}
+
+static int __rtnl_linkdump_req(struct rtnl_handle *rth, int family)
+{
+	struct {
+		struct nlmsghdr nlh;
+		struct ifinfomsg ifm;
+	} req = {
+		.nlh.nlmsg_len = NLMSG_LENGTH(sizeof(struct ifinfomsg)),
+		.nlh.nlmsg_type = RTM_GETLINK,
+		.nlh.nlmsg_flags = NLM_F_DUMP | NLM_F_REQUEST,
+		.nlh.nlmsg_seq = rth->dump = ++rth->seq,
+		.ifm.ifi_family = family,
+	};
+
+	return send(rth->fd, &req, sizeof(req), 0);
+}
+
+int rtnl_linkdump_req(struct rtnl_handle *rth, int family)
+{
+	if (family == AF_UNSPEC)
+		return rtnl_linkdump_req_filter(rth, family, RTEXT_FILTER_VF);
+
+	return __rtnl_linkdump_req(rth, family);
+}
+
+int rtnl_linkdump_req_filter(struct rtnl_handle *rth, int family,
+			    __u32 filt_mask)
+{
+	if (family == AF_UNSPEC || family == AF_BRIDGE) {
+		struct {
+			struct nlmsghdr nlh;
+			struct ifinfomsg ifm;
+			/* attribute has to be NLMSG aligned */
+			struct rtattr ext_req __aligned(NLMSG_ALIGNTO);
+			__u32 ext_filter_mask;
+		} req = {
+			.nlh.nlmsg_len = sizeof(req),
+			.nlh.nlmsg_type = RTM_GETLINK,
+			.nlh.nlmsg_flags = NLM_F_DUMP | NLM_F_REQUEST,
+			.nlh.nlmsg_seq = rth->dump = ++rth->seq,
+			.ifm.ifi_family = family,
+			.ext_req.rta_type = IFLA_EXT_MASK,
+			.ext_req.rta_len = RTA_LENGTH(sizeof(__u32)),
+			.ext_filter_mask = filt_mask,
+		};
+
+		return send(rth->fd, &req, sizeof(req), 0);
+	}
+
+	return __rtnl_linkdump_req(rth, family);
+}
+
+int rtnl_linkdump_req_filter_fn(struct rtnl_handle *rth, int family,
+				req_filter_fn_t filter_fn)
+{
+	if (family == AF_UNSPEC || family == AF_PACKET) {
+		struct {
+			struct nlmsghdr nlh;
+			struct ifinfomsg ifm;
+			char buf[1024];
+		} req = {
+			.nlh.nlmsg_len = NLMSG_LENGTH(sizeof(struct ifinfomsg)),
+			.nlh.nlmsg_type = RTM_GETLINK,
+			.nlh.nlmsg_flags = NLM_F_DUMP | NLM_F_REQUEST,
+			.nlh.nlmsg_seq = rth->dump = ++rth->seq,
+			.ifm.ifi_family = family,
+		};
+		int err;
+
+		if (!filter_fn)
+			return -EINVAL;
+
+		err = filter_fn(&req.nlh, sizeof(req));
+		if (err)
+			return err;
+
+		return send(rth->fd, &req, req.nlh.nlmsg_len, 0);
+	}
+
+	return __rtnl_linkdump_req(rth, family);
+}
+
+int rtnl_fdb_linkdump_req_filter_fn(struct rtnl_handle *rth,
+				    req_filter_fn_t filter_fn)
+{
+	struct {
+		struct nlmsghdr nlh;
+		struct ifinfomsg ifm;
+		char buf[128];
+	} req = {
+		.nlh.nlmsg_len = NLMSG_LENGTH(sizeof(struct ifinfomsg)),
+		.nlh.nlmsg_type = RTM_GETNEIGH,
+		.nlh.nlmsg_flags = NLM_F_DUMP | NLM_F_REQUEST,
+		.nlh.nlmsg_seq = rth->dump = ++rth->seq,
+		.ifm.ifi_family = PF_BRIDGE,
+	};
+	int err;
+
+	err = filter_fn(&req.nlh, sizeof(req));
+	if (err)
+		return err;
+
+	return send(rth->fd, &req, sizeof(req), 0);
+}
+
+int rtnl_statsdump_req_filter(struct rtnl_handle *rth, int fam,
+			      __u32 filt_mask,
+			      int (*filter_fn)(struct ipstats_req *req,
+					       void *data),
+			      void *filter_data)
+{
+	struct ipstats_req req;
+
+	memset(&req, 0, sizeof(req));
+	req.nlh.nlmsg_len = NLMSG_LENGTH(sizeof(struct if_stats_msg));
+	req.nlh.nlmsg_type = RTM_GETSTATS;
+	req.nlh.nlmsg_flags = NLM_F_DUMP|NLM_F_REQUEST;
+	req.nlh.nlmsg_pid = 0;
+	req.nlh.nlmsg_seq = rth->dump = ++rth->seq;
+	req.ifsm.family = fam;
+	req.ifsm.filter_mask = filt_mask;
+
+	if (filter_fn) {
+		int err;
+
+		err = filter_fn(&req, filter_data);
+		if (err)
+			return err;
+	}
+
+	return send(rth->fd, &req, sizeof(req), 0);
+}
+
+int rtnl_send(struct rtnl_handle *rth, const void *buf, int len)
+{
+	return send(rth->fd, buf, len, 0);
+}
+
+int rtnl_send_check(struct rtnl_handle *rth, const void *buf, int len)
+{
+	struct nlmsghdr *h;
+	int status;
+	char resp[1024];
+
+	status = send(rth->fd, buf, len, 0);
+	if (status < 0)
+		return status;
+
+	/* Check for immediate errors */
+	status = recv(rth->fd, resp, sizeof(resp), MSG_DONTWAIT|MSG_PEEK);
+	if (status < 0) {
+		if (errno == EAGAIN)
+			return 0;
+		return -1;
+	}
+
+	for (h = (struct nlmsghdr *)resp; NLMSG_OK(h, status);
+	     h = NLMSG_NEXT(h, status)) {
+		if (h->nlmsg_type == NLMSG_ERROR) {
+			struct nlmsgerr *err = (struct nlmsgerr *)NLMSG_DATA(h);
+
+			if (h->nlmsg_len < NLMSG_LENGTH(sizeof(struct nlmsgerr)))
+				ERROR("ERROR truncated");
+			else
+				errno = -err->error;
+			return -1;
+		}
+	}
+
+	return 0;
 }
 
 int rtnl_dump_request(struct rtnl_handle *rth, int type, void *req, int len)
 {
-	struct nlmsghdr nlh;
-	struct sockaddr_nl nladdr;
+	struct nlmsghdr nlh = {
+		.nlmsg_len = NLMSG_LENGTH(len),
+		.nlmsg_type = type,
+		.nlmsg_flags = NLM_F_DUMP | NLM_F_REQUEST,
+		.nlmsg_seq = rth->dump = ++rth->seq,
+	};
+	struct sockaddr_nl nladdr = { .nl_family = AF_NETLINK };
 	struct iovec iov[2] = {
-		{.iov_base = &nlh,.iov_len = sizeof(nlh)}
-		,
-		{.iov_base = req,.iov_len = len}
+		{ .iov_base = &nlh, .iov_len = sizeof(nlh) },
+		{ .iov_base = req, .iov_len = len }
 	};
 	struct msghdr msg = {
 		.msg_name = &nladdr,
@@ -155,109 +706,14 @@ int rtnl_dump_request(struct rtnl_handle *rth, int type, void *req, int len)
 		.msg_iovlen = 2,
 	};
 
-	memset(&nladdr, 0, sizeof(nladdr));
-	nladdr.nl_family = AF_NETLINK;
-
-	nlh.nlmsg_len = NLMSG_LENGTH(len);
-	nlh.nlmsg_type = type;
-	nlh.nlmsg_flags = NLM_F_ROOT | NLM_F_MATCH | NLM_F_REQUEST;
-	nlh.nlmsg_pid = 0;
-	nlh.nlmsg_seq = rth->dump = ++rth->seq;
-
 	return sendmsg(rth->fd, &msg, 0);
 }
 
-int rtnl_dump_filter(struct rtnl_handle *rth,
-		     rtnl_filter_t filter,
-		     void *arg1, rtnl_filter_t junk, void *arg2)
+int rtnl_dump_request_n(struct rtnl_handle *rth, struct nlmsghdr *n)
 {
-	struct sockaddr_nl nladdr;
-	struct iovec iov;
-	struct msghdr msg = {
-		.msg_name = &nladdr,
-		.msg_namelen = sizeof(nladdr),
-		.msg_iov = &iov,
-		.msg_iovlen = 1,
-	};
-	char buf[16384];
-
-	iov.iov_base = buf;
-	while (1) {
-		int status;
-		struct nlmsghdr *h;
-
-		iov.iov_len = sizeof(buf);
-		status = recvmsg(rth->fd, &msg, 0);
-
-		if (status < 0) {
-			if (errno == EINTR)
-				continue;
-			ERROR("OVERRUN");
-			continue;
-		}
-
-		if (status == 0) {
-			ERROR("EOF on netlink\n");
-			return -1;
-		}
-
-		h = (struct nlmsghdr *)buf;
-		while (NLMSG_OK(h, status)) {
-			int err;
-
-			if (nladdr.nl_pid != 0 ||
-			    h->nlmsg_pid != rth->local.nl_pid ||
-			    h->nlmsg_seq != rth->dump) {
-				if (junk) {
-					err = junk(&nladdr, h, arg2);
-					if (err < 0)
-						return err;
-				}
-				goto skip_it;
-			}
-
-			if (h->nlmsg_type == NLMSG_DONE)
-				return 0;
-			if (h->nlmsg_type == NLMSG_ERROR) {
-				struct nlmsgerr *err =
-				    (struct nlmsgerr *)NLMSG_DATA(h);
-				if (h->nlmsg_len <
-				    NLMSG_LENGTH(sizeof(struct nlmsgerr))) {
-					ERROR("ERROR truncated\n");
-				} else {
-					errno = -err->error;
-					ERROR("RTNETLINK answers");
-				}
-				return -1;
-			}
-			err = filter(&nladdr, h, arg1);
-			if (err < 0)
-				return err;
-
-		      skip_it:
-			h = NLMSG_NEXT(h, status);
-		}
-		if (msg.msg_flags & MSG_TRUNC) {
-			ERROR("Message truncated\n");
-			continue;
-		}
-		if (status) {
-			ERROR("!!!Remnant of size %d\n", status);
-			return -1;
-		}
-	}
-}
-
-int rtnl_talk(struct rtnl_handle *rtnl, struct nlmsghdr *n, pid_t peer,
-	      unsigned groups, struct nlmsghdr *answer,
-	      rtnl_filter_t junk, void *jarg)
-{
-	int status;
-	unsigned seq;
-	struct nlmsghdr *h;
-	struct sockaddr_nl nladdr;
+	struct sockaddr_nl nladdr = { .nl_family = AF_NETLINK };
 	struct iovec iov = {
-		.iov_base = (void *)n,
+		.iov_base = n,
 		.iov_len = n->nlmsg_len
 	};
 	struct msghdr msg = {
@@ -266,120 +722,144 @@ int rtnl_talk(struct rtnl_handle *rtnl, struct nlmsghdr *n, pid_t peer,
 		.msg_iov = &iov,
 		.msg_iovlen = 1,
 	};
-	char buf[16384];
 
-	memset(&nladdr, 0, sizeof(nladdr));
-	nladdr.nl_family = AF_NETLINK;
-	nladdr.nl_pid = peer;
-	nladdr.nl_groups = groups;
+	n->nlmsg_flags = NLM_F_DUMP|NLM_F_REQUEST;
+	n->nlmsg_pid = 0;
+	n->nlmsg_seq = rth->dump = ++rth->seq;
 
-	n->nlmsg_seq = seq = ++rtnl->seq;
+	return sendmsg(rth->fd, &msg, 0);
+}
 
-	if (answer == NULL)
-		n->nlmsg_flags |= NLM_F_ACK;
+static int rtnl_dump_done(struct nlmsghdr *h,
+			  const struct rtnl_dump_filter_arg *a)
+{
+	int len;
 
-	status = sendmsg(rtnl->fd, &msg, 0);
-
-	if (status < 0) {
-		ERROR("Cannot talk to rtnetlink");
+	if (h->nlmsg_len < NLMSG_LENGTH(sizeof(int))) {
+		ERROR("DONE truncated");
 		return -1;
 	}
 
-	memset(buf, 0, sizeof(buf));
+	len = *(int *)NLMSG_DATA(h);
 
-	iov.iov_base = buf;
+	if (len < 0) {
+		errno = -len;
 
-	while (1) {
-		iov.iov_len = sizeof(buf);
-		status = recvmsg(rtnl->fd, &msg, 0);
+		if (a->errhndlr && (a->errhndlr(h, a->arg2) & RTNL_SUPPRESS_NLMSG_DONE_NLERR))
+			return 0;
 
-		if (status < 0) {
-			if (errno == EINTR)
-				continue;
-			ERROR("OVERRUN");
-			continue;
-		}
-		if (status == 0) {
-			ERROR("EOF on netlink\n");
+		/* check for any messages returned from kernel */
+		if (nl_dump_ext_ack_done(h, sizeof(int), len))
+			return len;
+
+		switch (errno) {
+		case ENOENT:
+		case EOPNOTSUPP:
 			return -1;
+		case EMSGSIZE:
+			ERROR("Error: Buffer too small for object.");
+			break;
+		default:
+			ERROR("RTNETLINK answers: %m");
 		}
-		if (msg.msg_namelen != sizeof(nladdr)) {
-			ERROR("sender address length == %d\n",
-				msg.msg_namelen);
-			return -1;
-		}
-		for (h = (struct nlmsghdr *)buf; status >= sizeof(*h);) {
-			int err;
-			int len = h->nlmsg_len;
-			int l = len - sizeof(*h);
-
-			if (l < 0 || len > status) {
-				if (msg.msg_flags & MSG_TRUNC) {
-					ERROR("Truncated message\n");
-					return -1;
-				}
-				ERROR(
-					"!!!malformed message: len=%d\n", len);
-				return -1;
-			}
-
-			if (nladdr.nl_pid != peer ||
-			    h->nlmsg_pid != rtnl->local.nl_pid ||
-			    h->nlmsg_seq != seq) {
-				if (junk) {
-					err = junk(&nladdr, h, jarg);
-					if (err < 0)
-						return err;
-				}
-				/* Don't forget to skip that message. */
-				status -= NLMSG_ALIGN(len);
-				h = (struct nlmsghdr *)((char *)h +
-							NLMSG_ALIGN(len));
-				continue;
-			}
-
-			if (h->nlmsg_type == NLMSG_ERROR) {
-				struct nlmsgerr *err =
-				    (struct nlmsgerr *)NLMSG_DATA(h);
-				if (l < sizeof(struct nlmsgerr)) {
-					ERROR("ERROR truncated\n");
-				} else {
-					errno = -err->error;
-					if (errno == 0) {
-						if (answer)
-							memcpy(answer, h,
-							       h->nlmsg_len);
-						return 0;
-					}
-					ERROR("RTNETLINK answers");
-				}
-				return -1;
-			}
-			if (answer) {
-				memcpy(answer, h, h->nlmsg_len);
-				return 0;
-			}
-
-			ERROR("Unexpected reply!!!\n");
-
-			status -= NLMSG_ALIGN(len);
-			h = (struct nlmsghdr *)((char *)h + NLMSG_ALIGN(len));
-		}
-		if (msg.msg_flags & MSG_TRUNC) {
-			ERROR("Message truncated\n");
-			continue;
-		}
-		if (status) {
-			ERROR("!!!Remnant of size %d\n", status);
-			return -1;
-		}
+		return len;
 	}
+
+	/* check for any messages returned from kernel */
+	nl_dump_ext_ack(h, NULL);
+
+	return 0;
 }
 
-int rtnl_listen(struct rtnl_handle *rtnl, rtnl_filter_t handler, void *jarg)
+static int rtnl_dump_error(const struct rtnl_handle *rth,
+			    struct nlmsghdr *h,
+			    const struct rtnl_dump_filter_arg *a)
 {
-	int status;
-	struct nlmsghdr *h;
+
+	if (h->nlmsg_len < NLMSG_LENGTH(sizeof(struct nlmsgerr))) {
+		ERROR("ERROR truncated");
+	} else {
+		const struct nlmsgerr *err = (struct nlmsgerr *)NLMSG_DATA(h);
+
+		errno = -err->error;
+		if (rth->proto == NETLINK_SOCK_DIAG &&
+		    (errno == ENOENT ||
+		     errno == EOPNOTSUPP))
+			return -1;
+
+		if (a->errhndlr && (a->errhndlr(h, a->arg2) & RTNL_SUPPRESS_NLMSG_ERROR_NLERR))
+			return 0;
+
+		if (!(rth->flags & RTNL_HANDLE_F_SUPPRESS_NLERR))
+			ERROR("RTNETLINK answers: %m");
+	}
+
+	return -1;
+}
+
+static int __rtnl_recvmsg(int fd, struct msghdr *msg, int flags)
+{
+	int len;
+
+	do {
+		len = recvmsg(fd, msg, flags);
+	} while (len < 0 && (errno == EINTR || errno == EAGAIN));
+
+	if (len < 0) {
+		ERROR("netlink receive error %s (%d)",
+			strerror(errno), errno);
+		return -errno;
+	}
+
+	if (len == 0) {
+		ERROR("EOF on netlink");
+		return -ENODATA;
+	}
+
+	return len;
+}
+
+static int rtnl_recvmsg(int fd, struct msghdr *msg, char **answer)
+{
+	struct iovec *iov = msg->msg_iov;
+	char *buf;
+	int len;
+
+	iov->iov_base = NULL;
+	iov->iov_len = 0;
+
+	len = __rtnl_recvmsg(fd, msg, MSG_PEEK | MSG_TRUNC);
+	if (len < 0)
+		return len;
+
+	if (len < 32768)
+		len = 32768;
+	buf = malloc(len);
+	if (!buf) {
+		ERROR("malloc error: not enough buffer");
+		return -ENOMEM;
+	}
+
+	iov->iov_base = buf;
+	iov->iov_len = len;
+
+	len = __rtnl_recvmsg(fd, msg, 0);
+	if (len < 0) {
+		free(buf);
+		return len;
+	}
+
+	if (answer)
+		*answer = buf;
+	else
+		free(buf);
+
+	return len;
+}
+
+static int rtnl_dump_filter_l(struct rtnl_handle *rth,
+			      const struct rtnl_dump_filter_arg *arg)
+{
 	struct sockaddr_nl nladdr;
 	struct iovec iov;
 	struct msghdr msg = {
@@ -388,15 +868,358 @@ int rtnl_listen(struct rtnl_handle *rtnl, rtnl_filter_t handler, void *jarg)
 		.msg_iov = &iov,
 		.msg_iovlen = 1,
 	};
-	char buf[8192];
+	char *buf;
+	int dump_intr = 0;
 
-	memset(&nladdr, 0, sizeof(nladdr));
-	nladdr.nl_family = AF_NETLINK;
-	nladdr.nl_pid = 0;
-	nladdr.nl_groups = 0;
+	while (1) {
+		int status;
+		const struct rtnl_dump_filter_arg *a;
+		int found_done = 0;
+		int msglen = 0;
+
+		status = rtnl_recvmsg(rth->fd, &msg, &buf);
+		if (status < 0)
+			return status;
+
+		if (rth->dump_fp)
+			fwrite(buf, 1, NLMSG_ALIGN(status), rth->dump_fp);
+
+		for (a = arg; a->filter; a++) {
+			struct nlmsghdr *h = (struct nlmsghdr *)buf;
+
+			msglen = status;
+
+			while (NLMSG_OK(h, msglen)) {
+				int err = 0;
+
+				h->nlmsg_flags &= ~a->nc_flags;
+
+				if (nladdr.nl_pid != 0 ||
+				    h->nlmsg_pid != rth->local.nl_pid ||
+				    h->nlmsg_seq != rth->dump)
+					goto skip_it;
+
+				if (h->nlmsg_flags & NLM_F_DUMP_INTR)
+					dump_intr = 1;
+
+				if (h->nlmsg_type == NLMSG_DONE) {
+					err = rtnl_dump_done(h, a);
+					if (err < 0) {
+						free(buf);
+						return -1;
+					}
+
+					found_done = 1;
+					break; /* process next filter */
+				}
+
+				if (h->nlmsg_type == NLMSG_ERROR) {
+					err = rtnl_dump_error(rth, h, a);
+					if (err < 0) {
+						free(buf);
+						return -1;
+					}
+
+					goto skip_it;
+				}
+
+				if (!rth->dump_fp) {
+					err = a->filter(h, a->arg1);
+					if (err < 0) {
+						free(buf);
+						return err;
+					}
+				}
+
+skip_it:
+				h = NLMSG_NEXT(h, msglen);
+			}
+		}
+		free(buf);
+
+		if (found_done) {
+			if (dump_intr)
+				ERROR("Dump was interrupted and may be inconsistent.");
+			return 0;
+		}
+
+		if (msg.msg_flags & MSG_TRUNC) {
+			ERROR("Message truncated");
+			continue;
+		}
+		if (msglen) {
+			ERROR("!!!Remnant of size %d", msglen);
+			return -1;
+		}
+	}
+}
+
+int rtnl_dump_filter_nc(struct rtnl_handle *rth,
+			rtnl_filter_t filter,
+			void *arg1, __u16 nc_flags)
+{
+	const struct rtnl_dump_filter_arg a[] = {
+		{
+			.filter = filter, .arg1 = arg1,
+			.nc_flags = nc_flags,
+		},
+		{ },
+	};
+
+	return rtnl_dump_filter_l(rth, a);
+}
+
+int rtnl_dump_filter_errhndlr_nc(struct rtnl_handle *rth,
+		     rtnl_filter_t filter,
+		     void *arg1,
+		     rtnl_err_hndlr_t errhndlr,
+		     void *arg2,
+		     __u16 nc_flags)
+{
+	const struct rtnl_dump_filter_arg a[] = {
+		{
+			.filter = filter, .arg1 = arg1,
+			.errhndlr = errhndlr, .arg2 = arg2,
+			.nc_flags = nc_flags,
+		},
+		{ },
+	};
+
+	return rtnl_dump_filter_l(rth, a);
+}
+
+static void rtnl_talk_error(struct nlmsghdr *h, struct nlmsgerr *err,
+			    nl_ext_ack_fn_t errfn)
+{
+	if (nl_dump_ext_ack(h, errfn))
+		return;
+
+	ERROR("RTNETLINK answers: %s",
+		strerror(-err->error));
+}
+
+
+static int __rtnl_talk_iov(struct rtnl_handle *rtnl, struct iovec *iov,
+			   size_t iovlen, struct nlmsghdr **answer,
+			   bool show_rtnl_err, nl_ext_ack_fn_t errfn)
+{
+	struct sockaddr_nl nladdr = { .nl_family = AF_NETLINK };
+	struct iovec riov;
+	struct msghdr msg = {
+		.msg_name = &nladdr,
+		.msg_namelen = sizeof(nladdr),
+		.msg_iov = iov,
+		.msg_iovlen = iovlen,
+	};
+	unsigned int seq = 0;
+	struct nlmsghdr *h;
+	int i, status;
+	char *buf;
+
+	for (i = 0; i < iovlen; i++) {
+		h = iov[i].iov_base;
+		h->nlmsg_seq = seq = ++rtnl->seq;
+		if (answer == NULL)
+			h->nlmsg_flags |= NLM_F_ACK;
+	}
+
+	status = sendmsg(rtnl->fd, &msg, 0);
+	if (status < 0) {
+		ERROR("Cannot talk to rtnetlink: %m");
+		return -1;
+	}
+
+	/* change msg to use the response iov */
+	msg.msg_iov = &riov;
+	msg.msg_iovlen = 1;
+	i = 0;
+	while (1) {
+next:
+		status = rtnl_recvmsg(rtnl->fd, &msg, &buf);
+		++i;
+
+		if (status < 0)
+			return status;
+
+		if (msg.msg_namelen != sizeof(nladdr)) {
+			ERROR("sender address length == %d",
+				msg.msg_namelen);
+			free(buf);
+			return -1;
+		}
+		for (h = (struct nlmsghdr *)buf; status >= sizeof(*h); ) {
+			int len = h->nlmsg_len;
+			int l = len - sizeof(*h);
+
+			if (l < 0 || len > status) {
+				if (msg.msg_flags & MSG_TRUNC) {
+					ERROR("Truncated message");
+					free(buf);
+					return -1;
+				}
+				ERROR("!!!malformed message: len=%d",
+					len);
+				free(buf);
+				return -1;
+			}
+
+			if (nladdr.nl_pid != 0 ||
+			    h->nlmsg_pid != rtnl->local.nl_pid ||
+			    h->nlmsg_seq > seq || h->nlmsg_seq < seq - iovlen) {
+				/* Don't forget to skip that message. */
+				status -= NLMSG_ALIGN(len);
+				h = (struct nlmsghdr *)((char *)h + NLMSG_ALIGN(len));
+				continue;
+			}
+
+			if (h->nlmsg_type == NLMSG_ERROR) {
+				struct nlmsgerr *err = (struct nlmsgerr *)NLMSG_DATA(h);
+				int error = err->error;
+
+				if (l < sizeof(struct nlmsgerr)) {
+					ERROR("ERROR truncated");
+					free(buf);
+					return -1;
+				}
+
+				if (!error) {
+					/* check messages from kernel */
+					nl_dump_ext_ack(h, errfn);
+				} else {
+					errno = -error;
+
+					if (rtnl->proto != NETLINK_SOCK_DIAG &&
+					    show_rtnl_err)
+						rtnl_talk_error(h, err, errfn);
+				}
+
+				if (i < iovlen) {
+					free(buf);
+					goto next;
+				}
+
+				if (error) {
+					free(buf);
+					return -i;
+				}
+
+				if (answer)
+					*answer = (struct nlmsghdr *)buf;
+				else
+					free(buf);
+				return 0;
+			}
+
+			if (answer) {
+				*answer = (struct nlmsghdr *)buf;
+				return 0;
+			}
+
+			ERROR("Unexpected reply!!!");
+
+			status -= NLMSG_ALIGN(len);
+			h = (struct nlmsghdr *)((char *)h + NLMSG_ALIGN(len));
+		}
+		free(buf);
+
+		if (msg.msg_flags & MSG_TRUNC) {
+			ERROR("Message truncated");
+			continue;
+		}
+
+		if (status) {
+			ERROR("!!!Remnant of size %d", status);
+			return -1;
+		}
+	}
+}
+
+static int __rtnl_talk(struct rtnl_handle *rtnl, struct nlmsghdr *n,
+		       struct nlmsghdr **answer,
+		       bool show_rtnl_err, nl_ext_ack_fn_t errfn)
+{
+	struct iovec iov = {
+		.iov_base = n,
+		.iov_len = n->nlmsg_len
+	};
+
+	return __rtnl_talk_iov(rtnl, &iov, 1, answer, show_rtnl_err, errfn);
+}
+
+int rtnl_echo_talk(struct rtnl_handle *rtnl, struct nlmsghdr *n, int use_json,
+		   int (*print_info)(struct nlmsghdr *n, void *arg))
+{
+	struct nlmsghdr *answer;
+	int ret;
+
+	n->nlmsg_flags |= NLM_F_ECHO | NLM_F_ACK;
+
+	ret = rtnl_talk(rtnl, n, &answer);
+	if (ret)
+		return ret;
+
+	new_json_obj(use_json);
+	open_json_object(NULL);
+	print_info(answer, stdout);
+	close_json_object();
+	delete_json_obj();
+	free(answer);
+
+	return 0;
+}
+
+int rtnl_talk(struct rtnl_handle *rtnl, struct nlmsghdr *n,
+	      struct nlmsghdr **answer)
+{
+	return __rtnl_talk(rtnl, n, answer, true, NULL);
+}
+
+int rtnl_talk_suppress_rtnl_errmsg(struct rtnl_handle *rtnl, struct nlmsghdr *n,
+				   struct nlmsghdr **answer)
+{
+	return __rtnl_talk(rtnl, n, answer, false, NULL);
+}
+
+int rtnl_listen_all_nsid(struct rtnl_handle *rth)
+{
+	unsigned int on = 1;
+
+	if (setsockopt(rth->fd, SOL_NETLINK, NETLINK_LISTEN_ALL_NSID, &on,
+		       sizeof(on)) < 0) {
+		ERROR("NETLINK_LISTEN_ALL_NSID: %m");
+		return -1;
+	}
+	rth->flags |= RTNL_HANDLE_F_LISTEN_ALL_NSID;
+	return 0;
+}
+
+int rtnl_listen(struct rtnl_handle *rtnl,
+		rtnl_listen_filter_t handler,
+		void *jarg)
+{
+	int status;
+	struct nlmsghdr *h;
+	struct sockaddr_nl nladdr = { .nl_family = AF_NETLINK };
+	struct iovec iov;
+	struct msghdr msg = {
+		.msg_name = &nladdr,
+		.msg_namelen = sizeof(nladdr),
+		.msg_iov = &iov,
+		.msg_iovlen = 1,
+	};
+	char   buf[16384];
+	char   cmsgbuf[BUFSIZ];
 
 	iov.iov_base = buf;
 	while (1) {
+		struct rtnl_ctrl_data ctrl;
+		struct cmsghdr *cmsg;
+
+		if (rtnl->flags & RTNL_HANDLE_F_LISTEN_ALL_NSID) {
+			msg.msg_control = &cmsgbuf;
+			msg.msg_controllen = sizeof(cmsgbuf);
+		}
+
 		iov.iov_len = sizeof(buf);
 		status = recvmsg(rtnl->fd, &msg, 0);
 
@@ -405,64 +1228,75 @@ int rtnl_listen(struct rtnl_handle *rtnl, rtnl_filter_t handler, void *jarg)
 				continue;
 			if (errno == EAGAIN)
 				return 0;
-			ERROR("OVERRUN: recvmsg(): error %d : %s\n", errno, strerror(errno));
+			ERROR("netlink receive error %s (%d)",
+				strerror(errno), errno);
+			if (errno == ENOBUFS)
+				continue;
 			return -1;
 		}
 		if (status == 0) {
-			ERROR("EOF on netlink\n");
+			ERROR("EOF on netlink");
 			return -1;
 		}
 		if (msg.msg_namelen != sizeof(nladdr)) {
-			ERROR("Sender address length == %d\n",
+			ERROR("Sender address length == %d",
 				msg.msg_namelen);
 			return -1;
 		}
-		for (h = (struct nlmsghdr *)buf; status >= sizeof(*h);) {
+
+		if (rtnl->flags & RTNL_HANDLE_F_LISTEN_ALL_NSID) {
+			memset(&ctrl, 0, sizeof(ctrl));
+			ctrl.nsid = -1;
+			for (cmsg = CMSG_FIRSTHDR(&msg); cmsg;
+			     cmsg = CMSG_NXTHDR(&msg, cmsg))
+				if (cmsg->cmsg_level == SOL_NETLINK &&
+				    cmsg->cmsg_type == NETLINK_LISTEN_ALL_NSID &&
+				    cmsg->cmsg_len == CMSG_LEN(sizeof(int))) {
+					int *data = (int *)CMSG_DATA(cmsg);
+
+					ctrl.nsid = *data;
+				}
+		}
+
+		for (h = (struct nlmsghdr *)buf; status >= sizeof(*h); ) {
 			int err;
 			int len = h->nlmsg_len;
 			int l = len - sizeof(*h);
 
 			if (l < 0 || len > status) {
 				if (msg.msg_flags & MSG_TRUNC) {
-					ERROR("Truncated message\n");
+					ERROR("Truncated message");
 					return -1;
 				}
-				ERROR(
-					"!!!malformed message: len=%d\n", len);
+				ERROR("!!!malformed message: len=%d",
+					len);
 				return -1;
 			}
 
-			err = handler(&nladdr, h, jarg);
-			if (err < 0) {
-				ERROR("Handler returned %d\n", err);
+			err = handler(&ctrl, h, jarg);
+			if (err < 0)
 				return err;
-			}
 
 			status -= NLMSG_ALIGN(len);
 			h = (struct nlmsghdr *)((char *)h + NLMSG_ALIGN(len));
 		}
 		if (msg.msg_flags & MSG_TRUNC) {
-			ERROR("Message truncated\n");
+			ERROR("Message truncated");
 			continue;
 		}
 		if (status) {
-			ERROR("!!!Remnant of size %d\n", status);
+			ERROR("!!!Remnant of size %d", status);
 			return -1;
 		}
 	}
 }
 
-int rtnl_from_file(FILE * rtnl, rtnl_filter_t handler, void *jarg)
+int rtnl_from_file(FILE *rtnl, rtnl_listen_filter_t handler,
+		   void *jarg)
 {
-	int status;
-	struct sockaddr_nl nladdr;
-	char buf[8192];
-	struct nlmsghdr *h = (void *)buf;
-
-	memset(&nladdr, 0, sizeof(nladdr));
-	nladdr.nl_family = AF_NETLINK;
-	nladdr.nl_pid = 0;
-	nladdr.nl_groups = 0;
+	size_t status;
+	char buf[16384];
+	struct nlmsghdr *h = (struct nlmsghdr *)buf;
 
 	while (1) {
 		int err, len;
@@ -470,75 +1304,69 @@ int rtnl_from_file(FILE * rtnl, rtnl_filter_t handler, void *jarg)
 
 		status = fread(&buf, 1, sizeof(*h), rtnl);
 
-		if (status < 0) {
-			if (errno == EINTR)
-				continue;
-			ERROR("rtnl_from_file: fread");
+		if (status == 0 && feof(rtnl))
+			return 0;
+		if (status != sizeof(*h)) {
+			if (ferror(rtnl))
+				ERROR("rtnl_from_file: fread: %m");
+			if (feof(rtnl))
+				ERROR("rtnl-from_file: truncated message");
 			return -1;
 		}
-		if (status == 0)
-			return 0;
 
 		len = h->nlmsg_len;
 		l = len - sizeof(*h);
 
 		if (l < 0 || len > sizeof(buf)) {
-			ERROR("!!!malformed message: len=%d @%lu\n",
+			ERROR("!!!malformed message: len=%d @%lu",
 				len, ftell(rtnl));
 			return -1;
 		}
 
 		status = fread(NLMSG_DATA(h), 1, NLMSG_ALIGN(l), rtnl);
 
-		if (status < 0) {
-			ERROR("rtnl_from_file: fread");
-			return -1;
-		}
-		if (status < l) {
-			ERROR("rtnl-from_file: truncated message\n");
+		if (status != NLMSG_ALIGN(l)) {
+			if (ferror(rtnl))
+				ERROR("rtnl_from_file: fread: %m");
+			if (feof(rtnl))
+				ERROR("rtnl-from_file: truncated message");
 			return -1;
 		}
 
-		err = handler(&nladdr, h, jarg);
+		err = handler(NULL, h, jarg);
 		if (err < 0)
 			return err;
 	}
 }
 
-int addattr32(struct nlmsghdr *n, int maxlen, int type, __u32 data)
+int addattr(struct nlmsghdr *n, int maxlen, int type)
 {
-	int len = RTA_LENGTH(4);
-	struct rtattr *rta;
-	if (NLMSG_ALIGN(n->nlmsg_len) + len > maxlen) {
-		ERROR(
-			"addattr32: Error! max allowed bound %d exceeded\n",
-			maxlen);
-		return -1;
-	}
-	rta = NLMSG_TAIL(n);
-	rta->rta_type = type;
-	rta->rta_len = len;
-	memcpy(RTA_DATA(rta), &data, 4);
-	n->nlmsg_len = NLMSG_ALIGN(n->nlmsg_len) + len;
-	return 0;
+	return addattr_l(n, maxlen, type, NULL, 0);
 }
 
 int addattr8(struct nlmsghdr *n, int maxlen, int type, __u8 data)
 {
-	int len = RTA_LENGTH(1);
-	struct rtattr *rta;
-	if (NLMSG_ALIGN(n->nlmsg_len) + len > maxlen) {
-		ERROR(
-			"addattr8: Error! max allowed bound %d exceeded\n",
-			maxlen);
-		return -1;
-	}
-	rta = NLMSG_TAIL(n);
-	rta->rta_type = type;
-	rta->rta_len = len;
-	memcpy(RTA_DATA(rta), &data, 1);
-	n->nlmsg_len = NLMSG_ALIGN(n->nlmsg_len) + len;
-	return 0;
+	return addattr_l(n, maxlen, type, &data, sizeof(__u8));
+}
+
+int addattr16(struct nlmsghdr *n, int maxlen, int type, __u16 data)
+{
+	return addattr_l(n, maxlen, type, &data, sizeof(__u16));
+}
+
+int addattr32(struct nlmsghdr *n, int maxlen, int type, __u32 data)
+{
+	return addattr_l(n, maxlen, type, &data, sizeof(__u32));
+}
+
+int addattr64(struct nlmsghdr *n, int maxlen, int type, __u64 data)
+{
+	return addattr_l(n, maxlen, type, &data, sizeof(__u64));
+}
+
+int addattrstrz(struct nlmsghdr *n, int maxlen, int type, const char *str)
+{
+	return addattr_l(n, maxlen, type, str, strlen(str)+1);
 }
 
 int addattr_l(struct nlmsghdr *n, int maxlen, int type, const void *data,
@@ -548,15 +1376,15 @@ int addattr_l(struct nlmsghdr *n, int maxlen, int type, const void *data,
 	struct rtattr *rta;
 
 	if (NLMSG_ALIGN(n->nlmsg_len) + RTA_ALIGN(len) > maxlen) {
-		ERROR(
-			"addattr_l ERROR: message exceeded bound of %d\n",
+		ERROR("addattr_l ERROR: message exceeded bound of %d",
 			maxlen);
 		return -1;
 	}
 	rta = NLMSG_TAIL(n);
 	rta->rta_type = type;
 	rta->rta_len = len;
-	memcpy(RTA_DATA(rta), data, alen);
+	if (alen)
+		memcpy(RTA_DATA(rta), data, alen);
 	n->nlmsg_len = NLMSG_ALIGN(n->nlmsg_len) + RTA_ALIGN(len);
 	return 0;
 }
@@ -564,16 +1392,48 @@ int addattr_l(struct nlmsghdr *n, int maxlen, int type, const void *data,
 int addraw_l(struct nlmsghdr *n, int maxlen, const void *data, int len)
 {
 	if (NLMSG_ALIGN(n->nlmsg_len) + NLMSG_ALIGN(len) > maxlen) {
-		ERROR(
-			"addraw_l ERROR: message exceeded bound of %d\n",
+		ERROR("addraw_l ERROR: message exceeded bound of %d",
 			maxlen);
 		return -1;
 	}
 
 	memcpy(NLMSG_TAIL(n), data, len);
-	memset((void *)NLMSG_TAIL(n) + len, 0, NLMSG_ALIGN(len) - len);
+	memset((void *) NLMSG_TAIL(n) + len, 0, NLMSG_ALIGN(len) - len);
 	n->nlmsg_len = NLMSG_ALIGN(n->nlmsg_len) + NLMSG_ALIGN(len);
 	return 0;
+}
+
+struct rtattr *addattr_nest(struct nlmsghdr *n, int maxlen, int type)
+{
+	struct rtattr *nest = NLMSG_TAIL(n);
+
+	addattr_l(n, maxlen, type, NULL, 0);
+	return nest;
+}
+
+int addattr_nest_end(struct nlmsghdr *n, struct rtattr *nest)
+{
+	nest->rta_len = (void *)NLMSG_TAIL(n) - (void *)nest;
+	return n->nlmsg_len;
+}
+
+struct rtattr *addattr_nest_compat(struct nlmsghdr *n, int maxlen, int type,
+				   const void *data, int len)
+{
+	struct rtattr *start = NLMSG_TAIL(n);
+
+	addattr_l(n, maxlen, type, data, len);
+	addattr_nest(n, maxlen, type);
+	return start;
+}
+
+int addattr_nest_compat_end(struct nlmsghdr *n, struct rtattr *start)
+{
+	struct rtattr *nest = (void *)start + NLMSG_ALIGN(start->rta_len);
+
+	start->rta_len = (void *)NLMSG_TAIL(n) - (void *)start;
+	addattr_nest_end(n, nest);
+	return n->nlmsg_len;
 }
 
 int rta_addattr32(struct rtattr *rta, int maxlen, int type, __u32 data)
@@ -582,8 +1442,7 @@ int rta_addattr32(struct rtattr *rta, int maxlen, int type, __u32 data)
 	struct rtattr *subrta;
 
 	if (RTA_ALIGN(rta->rta_len) + len > maxlen) {
-		ERROR(
-			"rta_addattr32: Error! max allowed bound %d exceeded\n",
+		ERROR("rta_addattr32: Error! max allowed bound %d exceeded",
 			maxlen);
 		return -1;
 	}
@@ -602,15 +1461,15 @@ int rta_addattr_l(struct rtattr *rta, int maxlen, int type,
 	int len = RTA_LENGTH(alen);
 
 	if (RTA_ALIGN(rta->rta_len) + RTA_ALIGN(len) > maxlen) {
-		ERROR(
-			"rta_addattr_l: Error! max allowed bound %d exceeded\n",
+		ERROR("rta_addattr_l: Error! max allowed bound %d exceeded",
 			maxlen);
 		return -1;
 	}
 	subrta = (struct rtattr *)(((char *)rta) + RTA_ALIGN(rta->rta_len));
 	subrta->rta_type = type;
 	subrta->rta_len = len;
-	memcpy(RTA_DATA(subrta), data, alen);
+	if (alen)
+		memcpy(RTA_DATA(subrta), data, alen);
 	rta->rta_len = NLMSG_ALIGN(rta->rta_len) + RTA_ALIGN(len);
 	return 0;
 }
@@ -649,31 +1508,71 @@ int rta_nest_end(struct rtattr *rta, struct rtattr *nest)
 
 int parse_rtattr(struct rtattr *tb[], int max, struct rtattr *rta, int len)
 {
+	return parse_rtattr_flags(tb, max, rta, len, 0);
+}
+
+int parse_rtattr_flags(struct rtattr *tb[], int max, struct rtattr *rta,
+		       int len, unsigned short flags)
+{
+	unsigned short type;
+
 	memset(tb, 0, sizeof(struct rtattr *) * (max + 1));
 	while (RTA_OK(rta, len)) {
-		if (rta->rta_type <= max)
-			tb[rta->rta_type] = rta;
+		type = rta->rta_type & ~flags;
+		if ((type <= max) && (!tb[type]))
+			tb[type] = rta;
 		rta = RTA_NEXT(rta, len);
 	}
 	if (len)
-		ERROR("!!!Deficit %d, rta_len=%d\n", len,
-			rta->rta_len);
+		ERROR("!!!Deficit %d, rta_len=%d",
+			len, rta->rta_len);
 	return 0;
 }
 
-int parse_rtattr_byindex(struct rtattr *tb[], int max, struct rtattr *rta,
-			 int len)
+struct rtattr *parse_rtattr_one(int type, struct rtattr *rta, int len)
 {
-	int i = 0;
-
-	memset(tb, 0, sizeof(struct rtattr *) * max);
 	while (RTA_OK(rta, len)) {
-		if (rta->rta_type <= max && i < max)
-			tb[i++] = rta;
+		if (rta->rta_type == type)
+			return rta;
 		rta = RTA_NEXT(rta, len);
 	}
+
 	if (len)
-		ERROR("!!!Deficit %d, rta_len=%d\n", len,
-			rta->rta_len);
-	return i;
+		ERROR("!!!Deficit %d, rta_len=%d",
+			len, rta->rta_len);
+	return NULL;
+}
+
+int __parse_rtattr_nested_compat(struct rtattr *tb[], int max,
+				 struct rtattr *rta,
+				 int len)
+{
+	if (RTA_PAYLOAD(rta) < len)
+		return -1;
+	if (RTA_PAYLOAD(rta) >= RTA_ALIGN(len) + sizeof(struct rtattr)) {
+		rta = RTA_DATA(rta) + RTA_ALIGN(len);
+		return parse_rtattr_nested(tb, max, rta);
+	}
+	memset(tb, 0, sizeof(struct rtattr *) * (max + 1));
+	return 0;
+}
+
+int rtnl_tunneldump_req(struct rtnl_handle *rth, int family, int ifindex,
+			__u8 flags)
+{
+	struct {
+		struct nlmsghdr nlh;
+		struct tunnel_msg tmsg;
+		char buf[256];
+	} req = {
+		.nlh.nlmsg_len = NLMSG_LENGTH(sizeof(struct tunnel_msg)),
+		.nlh.nlmsg_type = RTM_GETTUNNEL,
+		.nlh.nlmsg_flags = NLM_F_DUMP | NLM_F_REQUEST,
+		.nlh.nlmsg_seq = rth->dump = ++rth->seq,
+		.tmsg.family = family,
+		.tmsg.flags = flags,
+		.tmsg.ifindex = ifindex,
+	};
+
+	return send(rth->fd, &req, sizeof(req), 0);
 }

--- a/libnetlink.h
+++ b/libnetlink.h
@@ -1,52 +1,220 @@
+/* SPDX-License-Identifier: GPL-2.0 */
 #ifndef __LIBNETLINK_H__
-#define __LIBNETLINK_H__
+#define __LIBNETLINK_H__ 1
 
 #include <stdio.h>
+#include <string.h>
+#include <endian.h>
 #include <asm/types.h>
 #include <linux/netlink.h>
 #include <linux/rtnetlink.h>
-#include <sys/types.h>
+#include <linux/if_link.h>
+#include <linux/if_addr.h>
+#include <linux/neighbour.h>
+#include <linux/netconf.h>
+#include <arpa/inet.h>
 
-struct rtnl_handle
-{
-    int fd;
-    struct sockaddr_nl local;
-    struct sockaddr_nl peer;
-    __u32 seq;
-    __u32 dump;
+struct rtnl_handle {
+	int			fd;
+	struct sockaddr_nl	local;
+	struct sockaddr_nl	peer;
+	__u32			seq;
+	__u32			dump;
+	int			proto;
+	FILE		       *dump_fp;
+#define RTNL_HANDLE_F_LISTEN_ALL_NSID		0x01
+#define RTNL_HANDLE_F_SUPPRESS_NLERR		0x02
+#define RTNL_HANDLE_F_STRICT_CHK		0x04
+	int			flags;
 };
 
-int rtnl_open(struct rtnl_handle *rth, unsigned subscriptions);
-int rtnl_open_byproto(struct rtnl_handle *rth, unsigned subscriptions,
-                      int protocol);
+struct nlmsg_list {
+	struct nlmsg_list *next;
+	struct nlmsghdr   h;
+};
+
+struct nlmsg_chain {
+	struct nlmsg_list *head;
+	struct nlmsg_list *tail;
+};
+
+struct ipstats_req {
+	struct nlmsghdr nlh;
+	struct if_stats_msg ifsm;
+	char buf[128];
+};
+
+extern int rcvbuf;
+
+int rtnl_open(struct rtnl_handle *rth, unsigned int subscriptions)
+	__attribute__((warn_unused_result));
+
+int rtnl_open_byproto(struct rtnl_handle *rth, unsigned int subscriptions,
+			     int protocol)
+	__attribute__((warn_unused_result));
+int rtnl_add_nl_group(struct rtnl_handle *rth, unsigned int group)
+	__attribute__((warn_unused_result));
 void rtnl_close(struct rtnl_handle *rth);
-int rtnl_wilddump_request(struct rtnl_handle *rth, int fam, int type);
-int rtnl_dump_request(struct rtnl_handle *rth, int type, void *req, int len);
+void rtnl_set_strict_dump(struct rtnl_handle *rth);
 
-typedef int (*rtnl_filter_t)(const struct sockaddr_nl *, struct nlmsghdr *n,
-                             void *);
-int rtnl_dump_filter(struct rtnl_handle *rth, rtnl_filter_t filter,
-                     void *arg1, rtnl_filter_t junk, void *arg2);
-int rtnl_talk(struct rtnl_handle *rtnl, struct nlmsghdr *n, pid_t peer,
-              unsigned groups, struct nlmsghdr *answer, rtnl_filter_t junk,
-              void *jarg);
-int rtnl_send(struct rtnl_handle *rth, const char *buf, int);
+typedef int (*req_filter_fn_t)(struct nlmsghdr *nlh, int reqlen);
 
+int rtnl_addrdump_req(struct rtnl_handle *rth, int family,
+		      req_filter_fn_t filter_fn)
+	__attribute__((warn_unused_result));
+int rtnl_addrlbldump_req(struct rtnl_handle *rth, int family)
+	__attribute__((warn_unused_result));
+int rtnl_routedump_req(struct rtnl_handle *rth, int family,
+		       req_filter_fn_t filter_fn)
+	__attribute__((warn_unused_result));
+int rtnl_ruledump_req(struct rtnl_handle *rth, int family)
+	__attribute__((warn_unused_result));
+int rtnl_neighdump_req(struct rtnl_handle *rth, int family,
+		       req_filter_fn_t filter_fn)
+	__attribute__((warn_unused_result));
+int rtnl_neightbldump_req(struct rtnl_handle *rth, int family)
+	__attribute__((warn_unused_result));
+int rtnl_mdbdump_req(struct rtnl_handle *rth, int family)
+	__attribute__((warn_unused_result));
+int rtnl_brvlandump_req(struct rtnl_handle *rth, int family, __u32 dump_flags)
+	__attribute__((warn_unused_result));
+int rtnl_netconfdump_req(struct rtnl_handle *rth, int family)
+	__attribute__((warn_unused_result));
+
+int rtnl_linkdump_req(struct rtnl_handle *rth, int fam)
+	__attribute__((warn_unused_result));
+int rtnl_linkdump_req_filter(struct rtnl_handle *rth, int fam, __u32 filt_mask)
+	__attribute__((warn_unused_result));
+
+int rtnl_linkdump_req_filter_fn(struct rtnl_handle *rth, int fam,
+				req_filter_fn_t fn)
+	__attribute__((warn_unused_result));
+int rtnl_fdb_linkdump_req_filter_fn(struct rtnl_handle *rth,
+				    req_filter_fn_t filter_fn)
+	__attribute__((warn_unused_result));
+int rtnl_nsiddump_req_filter_fn(struct rtnl_handle *rth, int family,
+				req_filter_fn_t filter_fn)
+	__attribute__((warn_unused_result));
+int rtnl_statsdump_req_filter(struct rtnl_handle *rth, int fam, __u32 filt_mask,
+			      int (*filter_fn)(struct ipstats_req *req,
+					       void *data),
+			      void *filter_data)
+	__attribute__((warn_unused_result));
+int rtnl_dump_request(struct rtnl_handle *rth, int type, void *req,
+			     int len)
+	__attribute__((warn_unused_result));
+int rtnl_dump_request_n(struct rtnl_handle *rth, struct nlmsghdr *n)
+	__attribute__((warn_unused_result));
+
+int rtnl_nexthopdump_req(struct rtnl_handle *rth, int family,
+			 req_filter_fn_t filter_fn)
+	__attribute__((warn_unused_result));
+int rtnl_nexthop_bucket_dump_req(struct rtnl_handle *rth, int family,
+				 req_filter_fn_t filter_fn)
+	__attribute__((warn_unused_result));
+
+int rtnl_tunneldump_req(struct rtnl_handle *rth, int family, int ifindex,
+			__u8 flags)
+	__attribute__((warn_unused_result));
+
+struct rtnl_ctrl_data {
+	int	nsid;
+};
+
+typedef int (*rtnl_filter_t)(struct nlmsghdr *n, void *);
+
+/**
+ * rtnl error handler called from
+ *      rtnl_dump_done()
+ *      rtnl_dump_error()
+ *
+ * Return value is a bitmask of the following values:
+ * RTNL_LET_NLERR
+ *      error handled as usual
+ * RTNL_SUPPRESS_NLMSG_DONE_NLERR
+ *      error in nlmsg_type == NLMSG_DONE will be suppressed
+ * RTNL_SUPPRESS_NLMSG_ERROR_NLERR
+ *      error in nlmsg_type == NLMSG_ERROR will be suppressed
+ *      and nlmsg will be skipped
+ * RTNL_SUPPRESS_NLERR - suppress error in both previous cases
+ */
+#define RTNL_LET_NLERR				0x01
+#define RTNL_SUPPRESS_NLMSG_DONE_NLERR		0x02
+#define RTNL_SUPPRESS_NLMSG_ERROR_NLERR		0x04
+#define RTNL_SUPPRESS_NLERR			0x06
+typedef int (*rtnl_err_hndlr_t)(struct nlmsghdr *n, void *);
+
+typedef int (*rtnl_listen_filter_t)(struct rtnl_ctrl_data *,
+				    struct nlmsghdr *n, void *);
+
+typedef int (*nl_ext_ack_fn_t)(const char *errmsg, uint32_t off,
+			       const struct nlmsghdr *inner_nlh);
+
+struct rtnl_dump_filter_arg {
+	rtnl_filter_t filter;
+	void *arg1;
+	rtnl_err_hndlr_t errhndlr;
+	void *arg2;
+	__u16 nc_flags;
+};
+
+int rtnl_dump_filter_nc(struct rtnl_handle *rth,
+			rtnl_filter_t filter,
+			void *arg, __u16 nc_flags);
+#define rtnl_dump_filter(rth, filter, arg) \
+	rtnl_dump_filter_nc(rth, filter, arg, 0)
+int rtnl_dump_filter_errhndlr_nc(struct rtnl_handle *rth,
+				 rtnl_filter_t filter,
+				 void *arg1,
+				 rtnl_err_hndlr_t errhndlr,
+				 void *arg2,
+				 __u16 nc_flags);
+#define rtnl_dump_filter_errhndlr(rth, filter, farg, errhndlr, earg) \
+	rtnl_dump_filter_errhndlr_nc(rth, filter, farg, errhndlr, earg, 0)
+
+int rtnl_echo_talk(struct rtnl_handle *rtnl, struct nlmsghdr *n, int json,
+		   int (*print_info)(struct nlmsghdr *n, void *arg))
+	__attribute__((warn_unused_result));
+int rtnl_talk(struct rtnl_handle *rtnl, struct nlmsghdr *n,
+	      struct nlmsghdr **answer)
+	__attribute__((warn_unused_result));
+int rtnl_talk_suppress_rtnl_errmsg(struct rtnl_handle *rtnl, struct nlmsghdr *n,
+				   struct nlmsghdr **answer)
+	__attribute__((warn_unused_result));
+int rtnl_send(struct rtnl_handle *rth, const void *buf, int)
+	__attribute__((warn_unused_result));
+int rtnl_send_check(struct rtnl_handle *rth, const void *buf, int)
+	__attribute__((warn_unused_result));
+int nl_dump_ext_ack(const struct nlmsghdr *nlh, nl_ext_ack_fn_t errfn);
+int nl_dump_ext_ack_done(const struct nlmsghdr *nlh, unsigned int offset, int error);
+
+int addattr(struct nlmsghdr *n, int maxlen, int type);
 int addattr8(struct nlmsghdr *n, int maxlen, int type, __u8 data);
+int addattr16(struct nlmsghdr *n, int maxlen, int type, __u16 data);
 int addattr32(struct nlmsghdr *n, int maxlen, int type, __u32 data);
-int addattr_l(struct nlmsghdr *n, int maxlen, int type, const void *data,
-              int alen);
+int addattr64(struct nlmsghdr *n, int maxlen, int type, __u64 data);
+int addattrstrz(struct nlmsghdr *n, int maxlen, int type, const char *data);
+
+int addattr_l(struct nlmsghdr *n, int maxlen, int type,
+	      const void *data, int alen);
 int addraw_l(struct nlmsghdr *n, int maxlen, const void *data, int len);
+struct rtattr *addattr_nest(struct nlmsghdr *n, int maxlen, int type);
+int addattr_nest_end(struct nlmsghdr *n, struct rtattr *nest);
+struct rtattr *addattr_nest_compat(struct nlmsghdr *n, int maxlen, int type,
+				   const void *data, int len);
+int addattr_nest_compat_end(struct nlmsghdr *n, struct rtattr *nest);
 int rta_addattr8(struct rtattr *rta, int maxlen, int type, __u8 data);
 int rta_addattr16(struct rtattr *rta, int maxlen, int type, __u16 data);
 int rta_addattr32(struct rtattr *rta, int maxlen, int type, __u32 data);
 int rta_addattr64(struct rtattr *rta, int maxlen, int type, __u64 data);
 int rta_addattr_l(struct rtattr *rta, int maxlen, int type,
-                         const void *data, int alen);
+		  const void *data, int alen);
 
 int parse_rtattr(struct rtattr *tb[], int max, struct rtattr *rta, int len);
-int parse_rtattr_byindex(struct rtattr *tb[], int max, struct rtattr *rta,
-                         int len);
+int parse_rtattr_flags(struct rtattr *tb[], int max, struct rtattr *rta,
+			      int len, unsigned short flags);
+struct rtattr *parse_rtattr_one(int type, struct rtattr *rta, int len);
+int __parse_rtattr_nested_compat(struct rtattr *tb[], int max, struct rtattr *rta, int len);
 
 struct rtattr *rta_nest(struct rtattr *rta, int maxlen, int type);
 int rta_nest_end(struct rtattr *rta, struct rtattr *nest);
@@ -56,12 +224,154 @@ int rta_nest_end(struct rtattr *rta, struct rtattr *nest);
 				    RTA_ALIGN((rta)->rta_len)))
 
 #define parse_rtattr_nested(tb, max, rta) \
-    (parse_rtattr((tb), (max), RTA_DATA(rta), RTA_PAYLOAD(rta)))
+	(parse_rtattr_flags((tb), (max), RTA_DATA(rta), RTA_PAYLOAD(rta), \
+			    NLA_F_NESTED))
 
-int rtnl_listen(struct rtnl_handle *, rtnl_filter_t handler, void *jarg);
-int rtnl_from_file(FILE *, rtnl_filter_t handler, void *jarg);
+#define parse_rtattr_one_nested(type, rta) \
+	(parse_rtattr_one(type, RTA_DATA(rta), RTA_PAYLOAD(rta)))
+
+#define parse_rtattr_nested_compat(tb, max, rta, data, len) \
+	({ data = RTA_PAYLOAD(rta) >= len ? RTA_DATA(rta) : NULL;	\
+		__parse_rtattr_nested_compat(tb, max, rta, len); })
+
+static inline __u8 rta_getattr_u8(const struct rtattr *rta)
+{
+	return *(__u8 *)RTA_DATA(rta);
+}
+static inline __u16 rta_getattr_u16(const struct rtattr *rta)
+{
+	return *(__u16 *)RTA_DATA(rta);
+}
+static inline __be16 rta_getattr_be16(const struct rtattr *rta)
+{
+	return ntohs(rta_getattr_u16(rta));
+}
+static inline __u32 rta_getattr_u32(const struct rtattr *rta)
+{
+	return *(__u32 *)RTA_DATA(rta);
+}
+static inline __be32 rta_getattr_be32(const struct rtattr *rta)
+{
+	return ntohl(rta_getattr_u32(rta));
+}
+static inline __u64 rta_getattr_u64(const struct rtattr *rta)
+{
+	__u64 tmp;
+
+	memcpy(&tmp, RTA_DATA(rta), sizeof(__u64));
+	return tmp;
+}
+static inline __u64 rta_getattr_uint(const struct rtattr *rta)
+{
+	switch (RTA_PAYLOAD(rta)) {
+	case sizeof(__u8):
+		return rta_getattr_u8(rta);
+	case sizeof(__u16):
+		return rta_getattr_u16(rta);
+	case sizeof(__u32):
+		return rta_getattr_u32(rta);
+	case sizeof(__u64):
+		return rta_getattr_u64(rta);
+	}
+	return -1ULL;
+}
+
+static inline __be64 rta_getattr_be64(const struct rtattr *rta)
+{
+	return htobe64(rta_getattr_u64(rta));
+}
+
+static inline __s32 rta_getattr_s32(const struct rtattr *rta)
+{
+	return *(__s32 *)RTA_DATA(rta);
+}
+static inline __s64 rta_getattr_s64(const struct rtattr *rta)
+{
+	__s64 tmp;
+
+	memcpy(&tmp, RTA_DATA(rta), sizeof(tmp));
+	return tmp;
+}
+static inline const char *rta_getattr_str(const struct rtattr *rta)
+{
+	return (const char *)RTA_DATA(rta);
+}
+static inline int rta_type(const struct rtattr *rta)
+{
+	return rta->rta_type & NLA_TYPE_MASK;
+}
+
+int rtnl_listen_all_nsid(struct rtnl_handle *);
+int rtnl_listen(struct rtnl_handle *, rtnl_listen_filter_t handler,
+		void *jarg);
+int rtnl_from_file(FILE *, rtnl_listen_filter_t handler,
+		   void *jarg);
 
 #define NLMSG_TAIL(nmsg) \
-    ((struct rtattr *) (((void *) (nmsg)) + NLMSG_ALIGN((nmsg)->nlmsg_len)))
+	((struct rtattr *) (((void *) (nmsg)) + NLMSG_ALIGN((nmsg)->nlmsg_len)))
+
+#ifndef IFA_RTA
+#define IFA_RTA(r) \
+	((struct rtattr *)(((char *)(r)) + NLMSG_ALIGN(sizeof(struct ifaddrmsg))))
+#endif
+#ifndef IFA_PAYLOAD
+#define IFA_PAYLOAD(n)	NLMSG_PAYLOAD(n, sizeof(struct ifaddrmsg))
+#endif
+
+#ifndef IFLA_RTA
+#define IFLA_RTA(r) \
+	((struct rtattr *)(((char *)(r)) + NLMSG_ALIGN(sizeof(struct ifinfomsg))))
+#endif
+#ifndef IFLA_PAYLOAD
+#define IFLA_PAYLOAD(n)	NLMSG_PAYLOAD(n, sizeof(struct ifinfomsg))
+#endif
+
+#ifndef NDA_RTA
+#define NDA_RTA(r) \
+	((struct rtattr *)(((char *)(r)) + NLMSG_ALIGN(sizeof(struct ndmsg))))
+#endif
+#ifndef NDA_PAYLOAD
+#define NDA_PAYLOAD(n)	NLMSG_PAYLOAD(n, sizeof(struct ndmsg))
+#endif
+
+#ifndef NDTA_RTA
+#define NDTA_RTA(r) \
+	((struct rtattr *)(((char *)(r)) + NLMSG_ALIGN(sizeof(struct ndtmsg))))
+#endif
+#ifndef NDTA_PAYLOAD
+#define NDTA_PAYLOAD(n) NLMSG_PAYLOAD(n, sizeof(struct ndtmsg))
+#endif
+
+#ifndef NETNS_RTA
+#define NETNS_RTA(r) \
+	((struct rtattr *)(((char *)(r)) + NLMSG_ALIGN(sizeof(struct rtgenmsg))))
+#endif
+#ifndef NETNS_PAYLOAD
+#define NETNS_PAYLOAD(n)	NLMSG_PAYLOAD(n, sizeof(struct rtgenmsg))
+#endif
+
+#ifndef IFLA_STATS_RTA
+#define IFLA_STATS_RTA(r) \
+	((struct rtattr *)(((char *)(r)) + NLMSG_ALIGN(sizeof(struct if_stats_msg))))
+#endif
+
+#ifndef BRVLAN_RTA
+#define BRVLAN_RTA(r) \
+	((struct rtattr *)(((char *)(r)) + NLMSG_ALIGN(sizeof(struct br_vlan_msg))))
+#endif
+
+#ifndef TUNNEL_RTA
+#define TUNNEL_RTA(r) \
+	((struct rtattr *)(((char *)(r)) + NLMSG_ALIGN(sizeof(struct tunnel_msg))))
+#endif
+
+/* User defined nlmsg_type which is used mostly for logging netlink
+ * messages from dump file */
+#define NLMSG_TSTAMP	15
+
+#define rtattr_for_each_nested(attr, nest) \
+	for ((attr) = (void *)RTA_DATA(nest); \
+	     RTA_OK(attr, RTA_PAYLOAD(nest) - ((char *)(attr) - (char *)RTA_DATA((nest)))); \
+	     (attr) = RTA_TAIL((attr)))
 
 #endif /* __LIBNETLINK_H__ */


### PR DESCRIPTION
Update our libnetlink copy to the version of iproute2 v7.0.0. This brings various enhancements:

* dynamic allocation of buffers instead of relying on callers to allocate them (and potentially overrun them)
* increased amount of accessors for netlink attributes
* type aware accessors for netlink attribute data
* per-object type filter functions
* etc

and a lot of fixes.

All users of the APIs were updated.

To fit into mstpd, the following changes were applied:

* dropped the include of `utils.h`, it was actually unused
* replaced `json_print.h` with stubs
* dropped the `#warning` for !LIBMNL (I don't want to bring new dependencies for now)

and the following changes reapplied:

* replaced all `fprintf(stderr, "foo\n")` with `ERROR("foo")`
* replaced all `perror("foo")` with `ERROR("foo: %m")`, fixing up several missing `%m` locations
* replaced all `exit(1)` with `return -1`, adding cleanup calls as necessary
* made `rtnl_listen()` return `0` on `EAGAIN`, instead of blocking

There is the potential of this breaking the build with old distributions with old kernel headers, if we find that we could start shipping a copy of kernel headers ourselves.

As a side effect this also fixes printing error strings returned from the kernel.

Before:

```
mstpd[837]: error, rtnl_talk: RTNETLINK answers
mstpd[837]: error, MSTP_OUT_set_state: swbridge:enp3s0f0 Couldn't set kernel bridge state blocking
```

After:

```
mstpd[780]: error, rtnl_talk_error: RTNETLINK answers: Network is down
mstpd[780]: error, MSTP_OUT_set_state: swbridge:enp3s0f0 Couldn't set kernel bridge state blocking
```

This should make debugging issues a bit easier.