### PR TITLE
bridge_track: skip setting STP states of down ports

### DIFF
--- a/bridge_track.c
+++ b/bridge_track.c
@@ -517,14 +517,26 @@ void MSTP_OUT_set_state(per_tree_port_t *ptp, int new_state)
             state_name = "disabled";
             break;
     }
+
+    if(!prt->sysdeps.up && (ptp->state != BR_STATE_DISABLED)
+       && (ptp->state != BR_STATE_BLOCKING))
+    {
+       ERROR_MSTINAME(ptp, "trying to set a down port to %s", state_name);
+       return;
+    }
+
     INFO_MSTINAME(ptp, "entering %s state", state_name);
 
     /* Translate new CIST state to the kernel bridge code */
     if(0 == ptp->MSTID)
     { /* CIST */
-        if(0 > br_set_state(&rth_state, prt->sysdeps.if_index, ptp->state))
-            ERROR_PRTNAME(prt, "Couldn't set kernel bridge state %s",
-                          state_name);
+        /* we can only modify STP states of up ports */
+        if(prt->sysdeps.up)
+        {
+            if(0 > br_set_state(&rth_state, prt->sysdeps.if_index, ptp->state))
+                ERROR_PRTNAME(prt, "Couldn't set kernel bridge state %s",
+                              state_name);
+        }
     }
 }
 


### PR DESCRIPTION
The kernel automatically sets ports going down to discarding/disabled, and ports going up to blocking.

While down, the kernel doesn't allow setting any STP states, so we should not attempt to do so.

This should be fine, since disabled ports should never be anything other than blocking/disabled, and freshly enabled ports start at blocking.

To ensure this assumption holds, add a check for STP state to be blocking or discarding for ports that are down.

Silences messages on startup like:

```
mstpd[780]: error, rtnl_talk_error: RTNETLINK answers: Network is down
mstpd[780]: error, MSTP_OUT_set_state: swbridge:enp3s0f0 Couldn't set kernel bridge state blocking
```