### PR TITLE
tests: add configuration name tests

### DIFF
--- a/tests/test_digest.c
+++ b/tests/test_digest.c
@@ -74,12 +74,97 @@ static void all_vid_mst_mod32_digest(void **state)
                         expected_digest, 16);
 }
 
+/* Setting a configuration name should set the name as expected */
+static void configuration_name(void **state)
+{
+    char conf_name[CONFIGURATION_NAME_LEN + 1];
+    bridge_t *br;
+
+    alloc_bridge_ports(state, &br, "BR_TEST", 0x200000000001, NULL, 0);
+
+    MSTP_IN_set_mst_config_id(br, 0, (__u8 *)"mstpd_configuration");
+
+    strncpy(conf_name, "mstpd_configuration", CONFIGURATION_NAME_LEN);
+    assert_memory_equal(br->MstConfigId.s.configuration_name, conf_name,
+                        CONFIGURATION_NAME_LEN);
+}
+
+/* Setting a zero-lengths configuration name results in it being all-zero */
+static void configuration_name_min(void **state)
+{
+    char conf_name[CONFIGURATION_NAME_LEN + 1] = { 0 };
+    bridge_t *br;
+
+    alloc_bridge_ports(state, &br, "BR_TEST", 0x200000000001, NULL, 0);
+
+
+    MSTP_IN_set_mst_config_id(br, 0, (__u8 *)"");
+
+    assert_memory_equal(br->MstConfigId.s.configuration_name, conf_name,
+                        CONFIGURATION_NAME_LEN);
+}
+
+/* Setting a 32 character long name results in the name being set with no NULL
+ * terminator */
+static void configuration_name_max(void **state)
+{
+    char conf_name[CONFIGURATION_NAME_LEN + 1];
+    bridge_t *br;
+
+    alloc_bridge_ports(state, &br, "BR_TEST", 0x200000000001, NULL, 0);
+
+    MSTP_IN_set_mst_config_id(br, 0, (__u8 *)"ThisIsAVeryLongConfigurationName");
+
+    strncpy(conf_name, "ThisIsAVeryLongConfigurationName", sizeof(conf_name));
+    assert_uint_equal(strlen(conf_name), CONFIGURATION_NAME_LEN);
+    assert_memory_equal(br->MstConfigId.s.configuration_name, conf_name,
+                        CONFIGURATION_NAME_LEN);
+}
+
+/* Setting a name longer than 32 characters results in the name being trunctated */
+static void configuration_name_over(void **state)
+{
+    char conf_name[CONFIGURATION_NAME_LEN + 3];
+    bridge_t *br;
+
+    alloc_bridge_ports(state, &br, "BR_TEST", 0x200000000001, NULL, 0);
+
+
+    MSTP_IN_set_mst_config_id(br, 0, (__u8 *)"ThisIsAReallyLongConfigurationName");
+
+    /* TODO: should this be truncated or rejected? */
+    strncpy(conf_name, "ThisIsAReallyLongConfigurationName", sizeof(conf_name));
+    assert_uint_equal(strlen(conf_name), CONFIGURATION_NAME_LEN + 2);
+    assert_memory_equal(br->MstConfigId.s.configuration_name, conf_name,
+                        CONFIGURATION_NAME_LEN);
+}
+/* Check that Any data after the null terminator is ignored/cleared */
+static void configuration_name_garbage(void **state)
+{
+    char conf_name[CONFIGURATION_NAME_LEN + 1];
+    bridge_t *br;
+
+    alloc_bridge_ports(state, &br, "BR_TEST", 0x200000000001, NULL, 0);
+
+    MSTP_IN_set_mst_config_id(br, 0, (__u8 *)"ThisIsAVeryLongConfigurationName");
+    MSTP_IN_set_mst_config_id(br, 0, (__u8*)"ShortName");
+
+    strncpy(conf_name, "ShortName", sizeof(conf_name));
+    assert_memory_equal(br->MstConfigId.s.configuration_name, conf_name,
+                        CONFIGURATION_NAME_LEN);
+}
+
 int main(int argc, char *argv[])
 {
     const struct CMUnitTest tests[] = {
         cmocka_unit_test_setup_teardown(all_vid_cist_digest, prepare_test, teardown_test),
         cmocka_unit_test_setup_teardown(all_vid_mst_1_digest, prepare_test, teardown_test),
         cmocka_unit_test_setup_teardown(all_vid_mst_mod32_digest, prepare_test, teardown_test),
+        cmocka_unit_test_setup_teardown(configuration_name, prepare_test, teardown_test),
+        cmocka_unit_test_setup_teardown(configuration_name_min, prepare_test, teardown_test),
+        cmocka_unit_test_setup_teardown(configuration_name_max, prepare_test, teardown_test),
+        cmocka_unit_test_setup_teardown(configuration_name_over, prepare_test, teardown_test),
+        cmocka_unit_test_setup_teardown(configuration_name_garbage, prepare_test, teardown_test),
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);


### PR DESCRIPTION
Add tests for setting configuration names:

* check that both limits are accepted (0, 32)
* check that the name is filled up with zeroes
* check that overlong names are truncated