### PR TITLE
drop extra newlines at end of log messages

### DIFF
--- a/brmon.c
+++ b/brmon.c
@@ -94,7 +94,7 @@ static int listen_msg(struct rtnl_ctrl_data *data, struct nlmsghdr *n,
 
     if(tb[IFLA_IFNAME] == NULL)
     {
-        ERROR("BUG: nil ifname\n");
+        ERROR("BUG: nil ifname");
         return -1;
     }
 
@@ -174,7 +174,7 @@ static inline void br_ev_handler(uint32_t events, struct epoll_event_handler *h)
 {
     if(rtnl_listen(&rth, listen_msg, stdout) < 0)
     {
-        ERROR("Error on bridge monitoring socket\n");
+        ERROR("Error on bridge monitoring socket");
     }
 }
 
@@ -182,31 +182,31 @@ int init_bridge_ops(void)
 {
     if(rtnl_open(&rth, RTMGRP_LINK) < 0)
     {
-        ERROR("Couldn't open rtnl socket for monitoring\n");
+        ERROR("Couldn't open rtnl socket for monitoring");
         return -1;
     }
 
     if(rtnl_open(&rth_state, 0) < 0)
     {
-        ERROR("Couldn't open rtnl socket for setting state\n");
+        ERROR("Couldn't open rtnl socket for setting state");
         return -1;
     }
 
     if(rtnl_linkdump_req(&rth, PF_BRIDGE) < 0)
     {
-        ERROR("Cannot send dump request: %m\n");
+        ERROR("Cannot send dump request: %m");
         return -1;
     }
 
     if(rtnl_dump_filter(&rth, dump_msg, stdout) < 0)
     {
-        ERROR("Dump terminated\n");
+        ERROR("Dump terminated");
         return -1;
     }
 
     if(fcntl(rth.fd, F_SETFL, O_NONBLOCK) < 0)
     {
-        ERROR("Error setting O_NONBLOCK: %m\n");
+        ERROR("Error setting O_NONBLOCK: %m");
         return -1;
     }
 

--- a/ctl_socket_client.c
+++ b/ctl_socket_client.c
@@ -161,7 +161,7 @@ int send_ctl_message(int cmd, void *inbuf, int lin, void *outbuf, int lout,
     }
     if(mhdr.lout != lout)
     {
-        ERROR("Error, unexpected result length %d, expected %d\n",
+        ERROR("Error, unexpected result length %d, expected %d",
               mhdr.lout, lout);
         return -1;
     }

--- a/epoll_loop.c
+++ b/epoll_loop.c
@@ -44,7 +44,7 @@ int init_epoll(void)
     int r = epoll_create(128);
     if(r < 0)
     {
-        ERROR("epoll_create failed: %m\n");
+        ERROR("epoll_create failed: %m");
         return -1;
     }
     epoll_fd = r;
@@ -62,7 +62,7 @@ int add_epoll(struct epoll_event_handler *h)
     int r = epoll_ctl(epoll_fd, EPOLL_CTL_ADD, h->fd, &ev);
     if(r < 0)
     {
-        ERROR("epoll_ctl_add: %m\n");
+        ERROR("epoll_ctl_add: %m");
         return -1;
     }
     return 0;
@@ -73,7 +73,7 @@ int remove_epoll(struct epoll_event_handler *h)
     int r = epoll_ctl(epoll_fd, EPOLL_CTL_DEL, h->fd, NULL);
     if(r < 0)
     {
-        ERROR("epoll_ctl_del: %m\n");
+        ERROR("epoll_ctl_del: %m");
         return -1;
     }
     if(h->ref_ev && h->ref_ev->data.ptr == h)
@@ -135,7 +135,7 @@ int epoll_main_loop(volatile bool *quit)
         r = epoll_wait(epoll_fd, ev, EV_SIZE, timeout);
         if(r < 0 && errno != EINTR)
         {
-            ERROR("epoll_wait: %m\n");
+            ERROR("epoll_wait: %m");
             return -1;
         }
         for(i = 0; i < r; ++i)

--- a/main.c
+++ b/main.c
@@ -154,7 +154,7 @@ int main(int argc, char *argv[])
     if(print_to_syslog)
         openlog(APP_NAME, LOG_PID, LOG_DAEMON);
 
-    INFO("Version - " PACKAGE_VERSION "\n");
+    INFO("Version - " PACKAGE_VERSION);
 
     if (sanity_check() < 0)
 	return EXIT_FAILURE;

--- a/netif_utils.c
+++ b/netif_utils.c
@@ -50,7 +50,7 @@ int netsock_init(void)
     netsock = socket(AF_INET, SOCK_DGRAM, 0);
     if(0 > netsock)
     {
-        ERROR("Couldn't open inet socket for ioctls: %m\n");
+        ERROR("Couldn't open inet socket for ioctls: %m");
         return -1;
     }
     return 0;
@@ -114,7 +114,7 @@ int ethtool_get_speed_duplex(char *ifname, int *speed, int *duplex)
     ifr.ifr_data = (caddr_t)&ecmd;
     if(0 > ioctl(netsock, SIOCETHTOOL, &ifr))
     {
-        ERROR("Cannot get speed/duplex for %s: %m\n", ifname);
+        ERROR("Cannot get speed/duplex for %s: %m", ifname);
         return -1;
     }
     *speed = ethtool_cmd_speed(&ecmd); /* Ethtool speed is in Mbps */


### PR DESCRIPTION
The logging function `vDprintf()` automatically appends a newline, so passing one at the end of the message would double it.

Therefore drop any newlines at the end of log messages.