### PR TITLE
do not claim PVST+ support

### DIFF
--- a/README.VLANs.md
+++ b/README.VLANs.md
@@ -5,7 +5,7 @@ There are currently two different ways to implement spanning tree on
 trunk ports using Linux bridging and mstpd:
 
 1. Single Spanning Tree (RSTP/STP)
-2. Per-VLAN Spanning Tree (PVST+)
+2. Per-VLAN Spanning Tree
 
 Single Spanning Tree (RSTP/STP)
 -------------------------------
@@ -28,8 +28,10 @@ with Cisco switches, you must put the Cisco switches in 'mst' mode
 (`spanning-tree mode mst`).  Cisco switches in 'mst' mode will fall back
 to PVST+ on ports connected to other switches that speak PVST+.
 
-Per-VLAN Spanning Tree (PVST+)
+Per-VLAN Spanning Tree
 ------------------------------
+
+**Note** this is not PVST+, which is a proprietary Cisco protocol.
 
 * Create Linux VLAN interfaces on top of each trunk interface.
 * For each VLAN, create a Linux bridge and attach the relevant VLAN
@@ -44,4 +46,8 @@ Per-VLAN Spanning Tree (PVST+)
 * Force mstpd to use RSTP on each bridge
   (`mstpctl setforcevers <bridge> rstp`).
 
-This is only compatible with other switches that speak PVST+.
+This is only compatible with other switches that run (R)STP in a similar
+manner, but is not compatible with switches running (rapid) PVST+.
+
+This is also not compatible with switchdev and by extension DSA backed
+switches, which do not support per-VLAN STP states.

--- a/mstpd.spec
+++ b/mstpd.spec
@@ -1,5 +1,5 @@
 Name:          mstpd
-Summary:       STP/RSTP/PVST+/MSTP Spanning Tree Protocol Daemon
+Summary:       STP/RSTP/MSTP Spanning Tree Protocol Daemon
 URL:           https://github.com/mstpd/mstpd
 Version:       0.2.0
 Release:       1%{?dist}
@@ -16,8 +16,7 @@ Requires: python3
 
 %description
 This package provides a user-space daemon which replaces the STP handling that
-is built into the Linux kernel Ethernet bridge and adds support for RSTP and
-PVST+.
+is built into the Linux kernel Ethernet bridge and adds support for RSTP.
 
 This daemon also supports participating in MSTP.  However, due to the way the
 Linux kernel implements its FIBs, it is not currently possible to map MSTP


### PR DESCRIPTION
PVST+ is a proprietary Cisco protocol that deviates from standard (R)STP in more than just VLAN tags for BPDUs; it also uses a different multicast address (01:00:0c:cc:cc:cd), as well as a different LLC PDU format.

mstpd currently only supports sending and receiving standard BPDUs via the standard multicast address 01:80:c2:00:00:00, so any PVST+ BPDUs will get ignored.

This makes running mstpd on per VLAN bridges incompatible with implementations running Cisco PVST+, and  we should not name our Per-VLAN Spanning Tree as such to avoid confusion.