### PR TITLE
README.md: clarify original sources attribution a bit

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,10 @@ ACKNOWLEDGEMENTS
 Initial code was written by looking at (and shamelessly stealing some
 parts from):
 
-  - rstpd by Srinivas Aji `<Aji_Srinivas ? emc DOT com>`
+  - [rstpd](https://github.com/shemminger/RSTP) by Srinivas Aji `<Aji_Srinivas
+    ? emc DOT com>` and Stephen Hemminger `<stephen ? networkplumber DOT org> ,
+    used as the base of `mstpd`
 
-  - rstplib by Alex Rozin `<alexr ? nbase DOT co DOT il>` and Michael
-  Rozhavsky `<mike ? nbase DOT co DOT il>`
+  - [rstplib](https://sourceforge.net/projects/rstplib/) by Alex Rozin `<alexr
+    ? nbase DOT co DOT il>` and Michael Rozhavsky `<mike ? nbase DOT co DOT
+    il>`, as inspiration for `mstp.{c,h}`


### PR DESCRIPTION
mstpd is rather obviously based on rstpd, though the rstplib used there was replaced with a self-written MSTP implementation.

Clarify a bit which parts were "stolen" (and from where), and add links to the original projects. Also add Stephen Hemminger to rstpd credits, since he also worked on it.

All sources actually taken over verbatim do have the original rstpd author attributions intact, so there is no need to touch any actual source files.