### PR TITLE
update license information

### DIFF
--- a/LICENSE.RSA-MD
+++ b/LICENSE.RSA-MD
@@ -1,0 +1,20 @@
+Copyright (C) 1991-2, RSA Data Security, Inc. Created 1991. All
+rights reserved.
+
+License to copy and use this software is granted provided that it
+is identified as the "RSA Data Security, Inc. MD5 Message-Digest
+Algorithm" in all material mentioning or referencing this software
+or this function.
+
+License is also granted to make and use derivative works provided
+that such works are identified as "derived from the RSA Data
+Security, Inc. MD5 Message-Digest Algorithm" in all material
+mentioning or referencing the derived work.
+
+RSA Data Security, Inc. makes no representations concerning either
+the merchantability of this software or the suitability of this
+software for any particular purpose. It is provided "as is"
+without express or implied warranty of any kind.
+
+These notices must be retained in any copies of any part of this
+documentation and/or software.

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 ACLOCAL_AMFLAGS = -I m4
 
 sbin_PROGRAMS = mstpd mstpctl

--- a/autogen.sh
+++ b/autogen.sh
@@ -1,3 +1,4 @@
 #!/bin/sh
+# SPDX-License-Identifier: GPL-2.0-or-later
 
 autoreconf -W portability -visf

--- a/bridge-stp.in
+++ b/bridge-stp.in
@@ -1,4 +1,5 @@
 #!/bin/sh
+# SPDX-License-Identifier: GPL-2.0-or-later
 #
 # Configuration is in @bridgestpconffile@
 #

--- a/bridge_ctl.h
+++ b/bridge_ctl.h
@@ -1,23 +1,7 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 /*****************************************************************************
   Copyright (c) 2006 EMC Corporation.
   Copyright (c) 2011 Factor-SPE
-
-  This program is free software; you can redistribute it and/or modify it
-  under the terms of the GNU General Public License as published by the Free
-  Software Foundation; either version 2 of the License, or (at your option)
-  any later version.
-
-  This program is distributed in the hope that it will be useful, but WITHOUT
-  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
-  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
-  more details.
-
-  You should have received a copy of the GNU General Public License along with
-  this program; if not, write to the Free Software Foundation, Inc., 59
-  Temple Place - Suite 330, Boston, MA  02111-1307, USA.
-
-  The full GNU General Public License is included in this distribution in the
-  file called LICENSE.
 
   Authors: Srinivas Aji <Aji_Srinivas@emc.com>
   Authors: Vitalii Demianets <dvitasgs@gmail.com>

--- a/bridge_track.c
+++ b/bridge_track.c
@@ -1,23 +1,7 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 /*****************************************************************************
   Copyright (c) 2006 EMC Corporation.
   Copyright (c) 2011 Factor-SPE
-
-  This program is free software; you can redistribute it and/or modify it
-  under the terms of the GNU General Public License as published by the Free
-  Software Foundation; either version 2 of the License, or (at your option)
-  any later version.
-
-  This program is distributed in the hope that it will be useful, but WITHOUT
-  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
-  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
-  more details.
-
-  You should have received a copy of the GNU General Public License along with
-  this program; if not, write to the Free Software Foundation, Inc., 59
-  Temple Place - Suite 330, Boston, MA  02111-1307, USA.
-
-  The full GNU General Public License is included in this distribution in the
-  file called LICENSE.
 
   Authors: Srinivas Aji <Aji_Srinivas@emc.com>
   Authors: Vitalii Demianets <dvitasgs@gmail.com>

--- a/bridge_track.h
+++ b/bridge_track.h
@@ -1,22 +1,4 @@
-/*****************************************************************************
-  This program is free software; you can redistribute it and/or modify it
-  under the terms of the GNU General Public License as published by the Free
-  Software Foundation; either version 2 of the License, or (at your option)
-  any later version.
-
-  This program is distributed in the hope that it will be useful, but WITHOUT
-  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
-  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
-  more details.
-
-  You should have received a copy of the GNU General Public License along with
-  this program; if not, write to the Free Software Foundation, Inc., 59
-  Temple Place - Suite 330, Boston, MA  02111-1307, USA.
-
-  The full GNU General Public License is included in this distribution in the
-  file called LICENSE.
-
-******************************************************************************/
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 
 #ifndef MSTPD_BRIDGE_TRACK_H
 #define MSTPD_BRIDGE_TRACK_H

--- a/brmon.c
+++ b/brmon.c
@@ -1,10 +1,6 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 /*
  * brmon.c      RTnetlink listener.
- *
- *  This program is free software; you can redistribute it and/or
- *  modify it under the terms of the GNU General Public License
- *  as published by the Free Software Foundation; either version
- *  2 of the License, or (at your option) any later version.
  *
  * Authors: Stephen Hemminger <shemminger@osdl.org>
  * Modified by Srinivas Aji <Aji_Srinivas@emc.com>

--- a/broadcom_xstrata/bcmexp.c
+++ b/broadcom_xstrata/bcmexp.c
@@ -1,9 +1,8 @@
+/* SPDX-License-Identifier: GPL-2.0 */
 /*
  * Based on Bill Evans's getmale.c
  *
  * Copyright (C) 2012 by Vladimir Cotfas <unix_router@yahoo.com>
- *
- * Released under GPLv2
  */
 #include <sys/select.h>
 #include <sys/types.h>

--- a/broadcom_xstrata/driver_deps.c
+++ b/broadcom_xstrata/driver_deps.c
@@ -1,10 +1,6 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 /*
  * driver_deps.c	Driver-specific code.
- *
- *  This program is free software; you can redistribute it and/or
- *  modify it under the terms of the GNU General Public License
- *  as published by the Free Software Foundation; either version
- *  2 of the License, or (at your option) any later version.
  *
  * Authors: Vitalii Demianets <dvitasgs@gmail.com>
  * Authors: Vladimir Cotfas <unix_router@yahoo.com> -- Broadcom Xstrata support

--- a/broadcom_xstrata/etc-init.d-stp.sh
+++ b/broadcom_xstrata/etc-init.d-stp.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 #
 # Copyright (C) 2012 by Phybridge Inc
+# SPDX-License-Identifier: GPL-2.0
 #
 PATH=/sbin:/usr/sbin:/bin:/usr/bin
 # source our service control routines

--- a/broadcom_xstrata/knet.soc
+++ b/broadcom_xstrata/knet.soc
@@ -1,5 +1,5 @@
+# SPDX-License-Identifier: GPL-2.0
 # Copyright (C) 2012 by Phybridge Inc
-# Released under GPLv2
 
 # ...
 

--- a/broadcom_xstrata/stp.soc
+++ b/broadcom_xstrata/stp.soc
@@ -1,5 +1,5 @@
+# SPDX-License-Identifier: GPL-2.0
 # Copyright (C) 2012 by Phybridge Inc
-# Released under GPLv2
 
 port ge3 stp=block
 port ge4 stp=block

--- a/clock_gettime.h
+++ b/clock_gettime.h
@@ -1,10 +1,6 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 /*
  * clock_gettime.h - clock_gettime() support with fallback to gettimeofday()
- *
- *  This program is free software; you can redistribute it and/or
- *  modify it under the terms of the GNU General Public License
- *  as published by the Free Software Foundation; either version
- *  2 of the License, or (at your option) any later version.
  *
  * Authors: Alexandru Ardelean <ardeleanalex@gmail.com>
  */

--- a/ctl_functions.h
+++ b/ctl_functions.h
@@ -1,23 +1,7 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 /*****************************************************************************
   Copyright (c) 2006 EMC Corporation.
   Copyright (c) 2011 Factor-SPE
-
-  This program is free software; you can redistribute it and/or modify it
-  under the terms of the GNU General Public License as published by the Free
-  Software Foundation; either version 2 of the License, or (at your option)
-  any later version.
-
-  This program is distributed in the hope that it will be useful, but WITHOUT
-  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
-  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
-  more details.
-
-  You should have received a copy of the GNU General Public License along with
-  this program; if not, write to the Free Software Foundation, Inc., 59
-  Temple Place - Suite 330, Boston, MA  02111-1307, USA.
-
-  The full GNU General Public License is included in this distribution in the
-  file called LICENSE.
 
   Authors: Srinivas Aji <Aji_Srinivas@emc.com>
   Authors: Vitalii Demianets <dvitasgs@gmail.com>

--- a/ctl_main.c
+++ b/ctl_main.c
@@ -1,22 +1,6 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 /*****************************************************************************
   Copyright (c) 2011 Factor-SPE
-
-  This program is free software; you can redistribute it and/or modify it
-  under the terms of the GNU General Public License as published by the Free
-  Software Foundation; either version 2 of the License, or (at your option)
-  any later version.
-
-  This program is distributed in the hope that it will be useful, but WITHOUT
-  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
-  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
-  more details.
-
-  You should have received a copy of the GNU General Public License along with
-  this program; if not, write to the Free Software Foundation, Inc., 59
-  Temple Place - Suite 330, Boston, MA  02111-1307, USA.
-
-  The full GNU General Public License is included in this distribution in the
-  file called LICENSE.
 
   Authors: Vitalii Demianets <dvitasgs@gmail.com>
 

--- a/ctl_socket_client.c
+++ b/ctl_socket_client.c
@@ -1,23 +1,7 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 /*****************************************************************************
   Copyright (c) 2006 EMC Corporation.
   Copyright (c) 2011 Factor-SPE
-
-  This program is free software; you can redistribute it and/or modify it
-  under the terms of the GNU General Public License as published by the Free
-  Software Foundation; either version 2 of the License, or (at your option)
-  any later version.
-
-  This program is distributed in the hope that it will be useful, but WITHOUT
-  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
-  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
-  more details.
-
-  You should have received a copy of the GNU General Public License along with
-  this program; if not, write to the Free Software Foundation, Inc., 59
-  Temple Place - Suite 330, Boston, MA  02111-1307, USA.
-
-  The full GNU General Public License is included in this distribution in the
-  file called LICENSE.
 
   Authors: Srinivas Aji <Aji_Srinivas@emc.com>
   Authors: Vitalii Demianets <dvitasgs@gmail.com>

--- a/ctl_socket_client.h
+++ b/ctl_socket_client.h
@@ -1,23 +1,7 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 /*****************************************************************************
   Copyright (c) 2006 EMC Corporation.
   Copyright (c) 2011 Factor-SPE
-
-  This program is free software; you can redistribute it and/or modify it
-  under the terms of the GNU General Public License as published by the Free
-  Software Foundation; either version 2 of the License, or (at your option)
-  any later version.
-
-  This program is distributed in the hope that it will be useful, but WITHOUT
-  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
-  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
-  more details.
-
-  You should have received a copy of the GNU General Public License along with
-  this program; if not, write to the Free Software Foundation, Inc., 59
-  Temple Place - Suite 330, Boston, MA  02111-1307, USA.
-
-  The full GNU General Public License is included in this distribution in the
-  file called LICENSE.
 
   Authors: Srinivas Aji <Aji_Srinivas@emc.com>
   Authors: Vitalii Demianets <dvitasgs@gmail.com>

--- a/ctl_socket_server.c
+++ b/ctl_socket_server.c
@@ -1,23 +1,7 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 /*****************************************************************************
   Copyright (c) 2006 EMC Corporation.
   Copyright (c) 2011 Factor-SPE
-
-  This program is free software; you can redistribute it and/or modify it
-  under the terms of the GNU General Public License as published by the Free
-  Software Foundation; either version 2 of the License, or (at your option)
-  any later version.
-
-  This program is distributed in the hope that it will be useful, but WITHOUT
-  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
-  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
-  more details.
-
-  You should have received a copy of the GNU General Public License along with
-  this program; if not, write to the Free Software Foundation, Inc., 59
-  Temple Place - Suite 330, Boston, MA  02111-1307, USA.
-
-  The full GNU General Public License is included in this distribution in the
-  file called LICENSE.
 
   Authors: Srinivas Aji <Aji_Srinivas@emc.com>
   Authors: Vitalii Demianets <dvitasgs@gmail.com>

--- a/ctl_socket_server.h
+++ b/ctl_socket_server.h
@@ -1,23 +1,7 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 /*****************************************************************************
   Copyright (c) 2006 EMC Corporation.
   Copyright (c) 2011 Factor-SPE
-
-  This program is free software; you can redistribute it and/or modify it
-  under the terms of the GNU General Public License as published by the Free
-  Software Foundation; either version 2 of the License, or (at your option)
-  any later version.
-
-  This program is distributed in the hope that it will be useful, but WITHOUT
-  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
-  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
-  more details.
-
-  You should have received a copy of the GNU General Public License along with
-  this program; if not, write to the Free Software Foundation, Inc., 59
-  Temple Place - Suite 330, Boston, MA  02111-1307, USA.
-
-  The full GNU General Public License is included in this distribution in the
-  file called LICENSE.
 
   Authors: Srinivas Aji <Aji_Srinivas@emc.com>
   Authors: Vitalii Demianets <dvitasgs@gmail.com>

--- a/driver.h
+++ b/driver.h
@@ -1,10 +1,6 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 /*
  * driver.h    Driver-specific code.
- *
- *  This program is free software; you can redistribute it and/or
- *  modify it under the terms of the GNU General Public License
- *  as published by the Free Software Foundation; either version
- *  2 of the License, or (at your option) any later version.
  *
  * Authors: Vitalii Demianets <dvitasgs@gmail.com>
  */

--- a/driver_deps.c
+++ b/driver_deps.c
@@ -1,10 +1,6 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 /*
  * driver_deps.c    Driver-specific code.
- *
- *  This program is free software; you can redistribute it and/or
- *  modify it under the terms of the GNU General Public License
- *  as published by the Free Software Foundation; either version
- *  2 of the License, or (at your option) any later version.
  *
  * Authors: Vitalii Demianets <dvitasgs@gmail.com>
  */

--- a/epoll_loop.c
+++ b/epoll_loop.c
@@ -1,23 +1,7 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 /*****************************************************************************
   Copyright (c) 2006 EMC Corporation.
   Copyright (c) 2011 Factor-SPE
-
-  This program is free software; you can redistribute it and/or modify it
-  under the terms of the GNU General Public License as published by the Free
-  Software Foundation; either version 2 of the License, or (at your option)
-  any later version.
-
-  This program is distributed in the hope that it will be useful, but WITHOUT
-  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
-  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
-  more details.
-
-  You should have received a copy of the GNU General Public License along with
-  this program; if not, write to the Free Software Foundation, Inc., 59
-  Temple Place - Suite 330, Boston, MA  02111-1307, USA.
-
-  The full GNU General Public License is included in this distribution in the
-  file called LICENSE.
 
   Authors: Srinivas Aji <Aji_Srinivas@emc.com>
   Authors: Vitalii Demianets <dvitasgs@gmail.com>

--- a/epoll_loop.h
+++ b/epoll_loop.h
@@ -1,23 +1,7 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 /*****************************************************************************
   Copyright (c) 2006 EMC Corporation.
   Copyright (c) 2011 Factor-SPE
-
-  This program is free software; you can redistribute it and/or modify it
-  under the terms of the GNU General Public License as published by the Free
-  Software Foundation; either version 2 of the License, or (at your option)
-  any later version.
-
-  This program is distributed in the hope that it will be useful, but WITHOUT
-  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
-  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
-  more details.
-
-  You should have received a copy of the GNU General Public License along with
-  this program; if not, write to the Free Software Foundation, Inc., 59
-  Temple Place - Suite 330, Boston, MA  02111-1307, USA.
-
-  The full GNU General Public License is included in this distribution in the
-  file called LICENSE.
 
   Authors: Srinivas Aji <Aji_Srinivas@emc.com>
   Authors: Vitalii Demianets <dvitasgs@gmail.com>

--- a/hmac_md5.c
+++ b/hmac_md5.c
@@ -1,24 +1,4 @@
-/* Copyright (C) 1991-2, RSA Data Security, Inc. Created 1991. All
-rights reserved.
-
-License to copy and use this software is granted provided that it
-is identified as the "RSA Data Security, Inc. MD5 Message-Digest
-Algorithm" in all material mentioning or referencing this software
-or this function.
-
-License is also granted to make and use derivative works provided
-that such works are identified as "derived from the RSA Data
-Security, Inc. MD5 Message-Digest Algorithm" in all material
-mentioning or referencing the derived work.
-
-RSA Data Security, Inc. makes no representations concerning either
-the merchantability of this software or the suitability of this
-software for any particular purpose. It is provided "as is"
-without express or implied warranty of any kind.
-
-These notices must be retained in any copies of any part of this
-documentation and/or software.
- */
+/* SPDX-License-Identifier: RSA-MD */
 
 #include <string.h>
 #include <sys/types.h>

--- a/list.h
+++ b/list.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: GPL-2.0 */
 /**
  * 
  * I grub it from linux kernel source code and fix it for user space

--- a/log.h
+++ b/log.h
@@ -1,23 +1,7 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 /*****************************************************************************
   Copyright (c) 2006 EMC Corporation.
   Copyright (c) 2011 Factor-SPE
-
-  This program is free software; you can redistribute it and/or modify it
-  under the terms of the GNU General Public License as published by the Free
-  Software Foundation; either version 2 of the License, or (at your option)
-  any later version.
-
-  This program is distributed in the hope that it will be useful, but WITHOUT
-  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
-  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
-  more details.
-
-  You should have received a copy of the GNU General Public License along with
-  this program; if not, write to the Free Software Foundation, Inc., 59
-  Temple Place - Suite 330, Boston, MA  02111-1307, USA.
-
-  The full GNU General Public License is included in this distribution in the
-  file called LICENSE.
 
   Authors: Srinivas Aji <Aji_Srinivas@emc.com>
   Authors: Vitalii Demianets <dvitasgs@gmail.com>

--- a/main.c
+++ b/main.c
@@ -1,23 +1,7 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 /*****************************************************************************
   Copyright (c) 2006 EMC Corporation.
   Copyright (c) 2011 Factor-SPE
-
-  This program is free software; you can redistribute it and/or modify it
-  under the terms of the GNU General Public License as published by the Free
-  Software Foundation; either version 2 of the License, or (at your option)
-  any later version.
-
-  This program is distributed in the hope that it will be useful, but WITHOUT
-  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
-  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
-  more details.
-
-  You should have received a copy of the GNU General Public License along with
-  this program; if not, write to the Free Software Foundation, Inc., 59
-  Temple Place - Suite 330, Boston, MA  02111-1307, USA.
-
-  The full GNU General Public License is included in this distribution in the
-  file called LICENSE.
 
   Authors: Srinivas Aji <Aji_Srinivas@emc.com>
   Authors: Vitalii Demianets <dvitasgs@gmail.com>

--- a/mstp.c
+++ b/mstp.c
@@ -1,10 +1,6 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 /*
  * mstp.c      State machines from IEEE 802.1Q-2005
- *
- *  This program is free software; you can redistribute it and/or
- *  modify it under the terms of the GNU General Public License
- *  as published by the Free Software Foundation; either version
- *  2 of the License, or (at your option) any later version.
  *
  * Authors: Vitalii Demianets <dvitasgs@gmail.com>
  */

--- a/mstp.h
+++ b/mstp.h
@@ -1,10 +1,6 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 /*
  * mstp.h      State machines from IEEE 802.1Q-2005
- *
- *  This program is free software; you can redistribute it and/or
- *  modify it under the terms of the GNU General Public License
- *  as published by the Free Software Foundation; either version
- *  2 of the License, or (at your option) any later version.
  *
  * Authors: Vitalii Demianets <dvitasgs@gmail.com>
  */

--- a/mstpd.spec
+++ b/mstpd.spec
@@ -4,7 +4,7 @@ URL:           https://github.com/mstpd/mstpd
 Version:       0.2.0
 Release:       1%{?dist}
 
-License:       GPLv2+
+License:       GPL-2.0-or-later AND GPL-2.0 AND RSA-MD
 Group:         System Environment/Daemons
 
 Source0:       https://github.com/mstpd/mstpd/archive/%{version}/%{name}-%{version}.tar.gz

--- a/netif_utils.c
+++ b/netif_utils.c
@@ -1,23 +1,7 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 /*****************************************************************************
   Copyright (c) 2006 EMC Corporation.
   Copyright (c) 2011 Factor-SPE
-
-  This program is free software; you can redistribute it and/or modify it
-  under the terms of the GNU General Public License as published by the Free
-  Software Foundation; either version 2 of the License, or (at your option)
-  any later version.
-
-  This program is distributed in the hope that it will be useful, but WITHOUT
-  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
-  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
-  more details.
-
-  You should have received a copy of the GNU General Public License along with
-  this program; if not, write to the Free Software Foundation, Inc., 59
-  Temple Place - Suite 330, Boston, MA  02111-1307, USA.
-
-  The full GNU General Public License is included in this distribution in the
-  file called LICENSE.
 
   Authors: Srinivas Aji <Aji_Srinivas@emc.com>
   Authors: Vitalii Demianets <dvitasgs@gmail.com>

--- a/netif_utils.h
+++ b/netif_utils.h
@@ -1,23 +1,7 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 /*****************************************************************************
   Copyright (c) 2006 EMC Corporation.
   Copyright (c) 2011 Factor-SPE
-
-  This program is free software; you can redistribute it and/or modify it
-  under the terms of the GNU General Public License as published by the Free
-  Software Foundation; either version 2 of the License, or (at your option)
-  any later version.
-
-  This program is distributed in the hope that it will be useful, but WITHOUT
-  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
-  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
-  more details.
-
-  You should have received a copy of the GNU General Public License along with
-  this program; if not, write to the Free Software Foundation, Inc., 59
-  Temple Place - Suite 330, Boston, MA  02111-1307, USA.
-
-  The full GNU General Public License is included in this distribution in the
-  file called LICENSE.
 
   Authors: Srinivas Aji <Aji_Srinivas@emc.com>
   Authors: Vitalii Demianets <dvitasgs@gmail.com>

--- a/packet.c
+++ b/packet.c
@@ -1,22 +1,6 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 /*****************************************************************************
   Copyright (c) 2006 EMC Corporation.
-
-  This program is free software; you can redistribute it and/or modify it
-  under the terms of the GNU General Public License as published by the Free
-  Software Foundation; either version 2 of the License, or (at your option)
-  any later version.
-
-  This program is distributed in the hope that it will be useful, but WITHOUT
-  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
-  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
-  more details.
-
-  You should have received a copy of the GNU General Public License along with
-  this program; if not, write to the Free Software Foundation, Inc., 59
-  Temple Place - Suite 330, Boston, MA  02111-1307, USA.
-
-  The full GNU General Public License is included in this distribution in the
-  file called LICENSE.
 
   Authors: Srinivas Aji <Aji_Srinivas@emc.com>
   Authors: Stephen Hemminger <shemminger@linux-foundation.org>

--- a/packet.h
+++ b/packet.h
@@ -1,22 +1,6 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 /*****************************************************************************
   Copyright (c) 2006 EMC Corporation.
-
-  This program is free software; you can redistribute it and/or modify it
-  under the terms of the GNU General Public License as published by the Free
-  Software Foundation; either version 2 of the License, or (at your option)
-  any later version.
-
-  This program is distributed in the hope that it will be useful, but WITHOUT
-  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
-  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
-  more details.
-
-  You should have received a copy of the GNU General Public License along with
-  this program; if not, write to the Free Software Foundation, Inc., 59
-  Temple Place - Suite 330, Boston, MA  02111-1307, USA.
-
-  The full GNU General Public License is included in this distribution in the
-  file called LICENSE.
 
   Authors: Srinivas Aji <Aji_Srinivas@emc.com>
 

--- a/utils/bash_completion
+++ b/utils/bash_completion
@@ -1,4 +1,5 @@
 # bash completion for mstpctl                                -*- shell-script -*-
+# SPDX-License-Identifier: GPL-2.0-or-later
 
 _mstpctl()
 {

--- a/utils/bridge-stp.8
+++ b/utils/bridge-stp.8
@@ -1,3 +1,4 @@
+.\" SPDX-License-Identifier: GPL-2.0-or-later
 .Dd April 28, 2026
 .Dt BRIDGE-STP 8
 .Os

--- a/utils/ifquery
+++ b/utils/ifquery
@@ -1,4 +1,5 @@
 #!/usr/bin/python3
+# SPDX-License-Identifier: GPL-2.0-or-later
 # Crudely emulate ifquery on systems that don't have it.
 
 import sys

--- a/utils/ifupdown.sh.in
+++ b/utils/ifupdown.sh.in
@@ -1,4 +1,5 @@
 #!/bin/sh
+# SPDX-License-Identifier: GPL-2.0-or-later
 
 # This script should be symlinked into /etc/network/ip-pre-up.d/ and
 # /etc/network/ip-post-down.d/ on Debian/Ubuntu systems so that it will be run

--- a/utils/mstp_config_bridge.in
+++ b/utils/mstp_config_bridge.in
@@ -1,4 +1,5 @@
 #!/bin/sh
+# SPDX-License-Identifier: GPL-2.0-or-later
 #
 # This script uses `ifquery` to read the config in
 # /etc/network/interfaces and then runs the mstpctl-utils

--- a/utils/mstp_restart.8
+++ b/utils/mstp_restart.8
@@ -1,3 +1,4 @@
+.\" SPDX-License-Identifier: GPL-2.0-or-later
 .Dd April 28, 2026
 .Dt MSTP_RESTART 8
 .Os

--- a/utils/mstpctl-utils-functions.sh
+++ b/utils/mstpctl-utils-functions.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+# SPDX-License-Identifier: GPL-2.0-or-later
 
 mstpctl_parse_ports()
 {

--- a/utils/mstpctl-utils-interfaces.5
+++ b/utils/mstpctl-utils-interfaces.5
@@ -1,3 +1,4 @@
+.\" SPDX-License-Identifier: GPL-2.0-or-later
 .\" -*- nroff -*-
 .\" macros
 .de EX \" Begin Example

--- a/utils/mstpctl.8
+++ b/utils/mstpctl.8
@@ -1,19 +1,4 @@
-.\"
-.\"	This program is free software; you can redistribute it and/or modify
-.\"	it under the terms of the GNU General Public License as published by
-.\"	the Free Software Foundation; either version 2 of the License, or
-.\"	(at your option) any later version.
-.\"
-.\"	This program is distributed in the hope that it will be useful,
-.\"	but WITHOUT ANY WARRANTY; without even the implied warranty of
-.\"	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-.\"	GNU General Public License for more details.
-.\"
-.\"	You should have received a copy of the GNU General Public License
-.\"	along with this program; if not, write to the Free Software
-.\"	Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
-.\"
-.\"
+.\" SPDX-License-Identifier: GPL-2.0-or-later
 .TH MSTPCTL 8 "April 29, 2013" "" ""
 .SH NAME
 mstpctl \- mstpd configuration

--- a/utils/mstpd.8
+++ b/utils/mstpd.8
@@ -1,3 +1,4 @@
+.\" SPDX-License-Identifier: GPL-2.0-or-later
 .Dd April 28, 2026
 .Dt MSTPD 8
 .Os

--- a/utils/nm-dispatcher.in
+++ b/utils/nm-dispatcher.in
@@ -1,4 +1,5 @@
 #!/bin/sh
+# SPDX-License-Identifier: GPL-2.0-or-later
 # This is a NetworkManager dispatcher script for the mstpd daemon
 # to apply any configuration to bridges based on the values in
 # /etc/sysconfig/network-scripts/bridge-stp


### PR DESCRIPTION
There are multiple (code) files missing license information, so let's add it where it's missing and use modern SPDX tags.

Accordingly update `mstpd.spec` to list all licenses found in the project.